### PR TITLE
Refactor library to improve readability of diffs

### DIFF
--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -49,6 +49,26 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
         break
     }
 
+    switch (lhsMirror.displayStyle, rhsMirror.displayStyle) {
+    case (.dictionary?, .dictionary?):
+        if let expectedDict = expected as? Dictionary<AnyHashable, Any>,
+            let receivedDict = received as? Dictionary<AnyHashable, Any> {
+
+            Array(expectedDict.keys).forEach { key in
+                var results = [String]()
+                diff(expectedDict[key], receivedDict[key], level: level + 1) { diff in
+                    results.append(diff)
+                }
+                if !results.isEmpty {
+                    closure("child key \(key.description):\n\(indentation(level: max(level, 1)))" + results.joined())
+                }
+            }
+            return
+        }
+    default:
+        break
+    }
+
     let zipped = zip(lhsMirror.children, rhsMirror.children)
     zipped.forEach { (lhs, rhs) in
         let leftDump = String(dumping: lhs.value)

--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -52,7 +52,7 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
                     results.append(diff)
                 }
                 if !results.isEmpty {
-                    closure("child key \(key.description):\n\(indentation(level: max(level, 1)))" + results.joined())
+                    closure("child key \(key.description):\n\(indentation(level: max(level, 1)))" + results.joined(separator: "\n\(indentation(level: max(level, 1)))"))
                 }
             }
             return
@@ -64,22 +64,18 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
             let uniqueExpected = expectedSet.subtracting(receivedSet)
             let uniqueReceived = receivedSet.subtracting(expectedSet)
 
-//            let something = Array(uniqueExpected).sorted { (lhs, rhs) -> Bool in
-//                if let lhsComp = lhs as? Comparable {
-//
+            var results = [String]()
+            uniqueExpected.forEach { unique in
+                results.append("SetElement missing: \(unique.description)\n")
+            }
+//            zip(uniqueExpected, uniqueReceived).forEach { lhs, rhs in
+//                diff(lhs, rhs, level: level + 1) { diff in
+//                    results.append("\(indentation(level: max(level, 1)))\(diff)")
 //                }
 //            }
-
-
-
-            var results = [String]()
-            zip(uniqueExpected, uniqueReceived).forEach { lhs, rhs in
-                diff(lhs, rhs, level: level + 1) { diff in
-                    results.append("\(indentation(level: max(level, 1)))\(diff)")
-                }
-            }
-            if !results.isEmpty {
-                closure("Set mismatch:\n" + results.joined())
+            if !uniqueExpected.isEmpty {
+//                closure("ExpectedSet missing:\n" + Array(uniqueExpected).map { $0.description }.joined())
+                closure("ExpectedSet missing:\n\(indentation(level: max(level, 1)))" + results.joined(separator: "\(indentation(level: max(level, 1)))"))
             }
             return
         }
@@ -100,7 +96,7 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
                     results.append(diff)
                 }
                 if !results.isEmpty {
-                    closure("child \(lhs.label ?? ""):\n\(indentation(level: level))" + results.joined())
+                    closure("child \(lhs.label ?? ""):\n\(indentation(level: level))" + results.joined(separator: "\(indentation(level: level))"))
                 }
             } else {
                 closure("\(lhs.label ?? "") received: \"\(rhs.value)\" expected: \"\(lhs.value)\"\n")

--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -118,7 +118,8 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
                     results.append(diff)
                 }
                 if !results.isEmpty {
-                    closure("R2 Child key \(key.description):\n\(indentation(level: max(level + 1, 1)))" + results.joined(separator: "\n\(indentation(level: max(level + 1, 1)))"))
+                    let header = "R2\(indentation(level: level))Child key \(key.description):\n"
+                    closure(header + results.joined())
                 }
             }
             return

--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -32,29 +32,20 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
         return
     }
 
+    let hasDiffNumOfChildren = lhsMirror.children.count != rhsMirror.children.count
     switch (lhsMirror.displayStyle, rhsMirror.displayStyle) {
-    case (.collection?, .collection?), (.dictionary?, .dictionary?):
-        if lhsMirror.children.count != rhsMirror.children.count {
+    case (.collection?, .collection?) where hasDiffNumOfChildren,
+         (.dictionary?, .dictionary?) where hasDiffNumOfChildren:
             closure("""
                 different count:
                 \(indentation(level: level))received: \"\(received)\" (\(rhsMirror.children.count))
                 \(indentation(level: level))expected: \"\(expected)\" (\(lhsMirror.children.count))\n
                 """)
-            return
-        }
-    case (.enum?, .enum?) where lhsMirror.children.first?.label != rhsMirror.children.first?.label,
-         (.optional?, .optional?) where lhsMirror.children.count != rhsMirror.children.count:
-        closure("received: \"\(received)\" expected: \"\(expected)\"\n")
-    default:
-        break
-    }
-
-    switch (lhsMirror.displayStyle, rhsMirror.displayStyle) {
+        return
     case (.dictionary?, .dictionary?):
         if let expectedDict = expected as? Dictionary<AnyHashable, Any>,
             let receivedDict = received as? Dictionary<AnyHashable, Any> {
-
-            Array(expectedDict.keys).forEach { key in
+            expectedDict.keys.forEach { key in
                 var results = [String]()
                 diff(expectedDict[key], receivedDict[key], level: level + 1) { diff in
                     results.append(diff)
@@ -65,6 +56,9 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
             }
             return
         }
+    case (.enum?, .enum?) where lhsMirror.children.first?.label != rhsMirror.children.first?.label,
+         (.optional?, .optional?) where hasDiffNumOfChildren:
+        closure("received: \"\(received)\" expected: \"\(expected)\"\n")
     default:
         break
     }

--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -1,66 +1,14 @@
+//
+//  Difference.swift
+//  Difference
+//
+//  Created by Krzysztof Zablocki on 18.10.2017
+//  Copyright © 2017 Krzysztof Zablocki. All rights reserved.
+//
+
 import Foundation
-/*
- TODO:
-    1. Remove Keypath prefixes
-    2. Sort results
-    3. Remove "some" child
- */
-public enum Difference {
-    /// Styling of the diff indentation.
-    /// `pipe` example:
-    ///     address:
-    ///     |    street:
-    ///     |    |    Received: 2nd Street
-    ///     |    |    Expected: Times Square
-    ///     |    counter:
-    ///     |    |    counter:
-    ///     |    |    |    Received: 1
-    ///     |    |    |    Expected: 2
-    /// `tab` example:
-    ///     address:
-    ///         street:
-    ///             Received: 2nd Street
-    ///             Expected: Times Square
-    ///         counter:
-    ///             counter:
-    ///                 Received: 1
-    ///                 Expected: 2
-    public enum IndentationType: String {
-        case pipe = "|\t"
-        case tab = "\t"
-    }
-}
 
 private typealias IndentationType = Difference.IndentationType
-
-private struct Line {
-    let contents: String
-    let indentationLevel: Int
-    let children: [Line]
-
-    var hasChildren: Bool { !children.isEmpty }
-
-    init(
-        contents: String,
-        indentationLevel: Int,
-        children: [Line] = []
-    ) {
-        self.contents = contents
-        self.indentationLevel = indentationLevel
-        self.children = children
-    }
-
-    func generateContents(indentationType: IndentationType) -> String {
-        let indentationString = indentation(level: indentationLevel, indentationType: indentationType)
-        let childrenContents = children.map { $0.generateContents(indentationType: indentationType)}
-            .joined()
-        return "\(indentationString)\(contents)\n" + childrenContents
-    }
-
-    private func indentation(level: Int, indentationType: IndentationType) -> String {
-        (0..<level).reduce("") { acc, _ in acc + "\(indentationType.rawValue)" }
-    }
-}
 
 fileprivate func diffLines<T>(_ expected: T, _ received: T, level: Int = 0) -> [Line] {
     let expectedMirror = Mirror(reflecting: expected)
@@ -137,6 +85,61 @@ fileprivate func diffLines<T>(_ expected: T, _ received: T, level: Int = 0) -> [
         }
     }
     return resultLines
+}
+
+public enum Difference {
+    /// Styling of the diff indentation.
+    /// `pipe` example:
+    ///     address:
+    ///     |    street:
+    ///     |    |    Received: 2nd Street
+    ///     |    |    Expected: Times Square
+    ///     |    counter:
+    ///     |    |    counter:
+    ///     |    |    |    Received: 1
+    ///     |    |    |    Expected: 2
+    /// `tab` example:
+    ///     address:
+    ///         street:
+    ///             Received: 2nd Street
+    ///             Expected: Times Square
+    ///         counter:
+    ///             counter:
+    ///                 Received: 1
+    ///                 Expected: 2
+    public enum IndentationType: String {
+        case pipe = "|\t"
+        case tab = "\t"
+    }
+}
+
+private struct Line {
+    let contents: String
+    let indentationLevel: Int
+    let children: [Line]
+
+    var hasChildren: Bool { !children.isEmpty }
+
+    init(
+        contents: String,
+        indentationLevel: Int,
+        children: [Line] = []
+    ) {
+        self.contents = contents
+        self.indentationLevel = indentationLevel
+        self.children = children
+    }
+
+    func generateContents(indentationType: IndentationType) -> String {
+        let indentationString = indentation(level: indentationLevel, indentationType: indentationType)
+        let childrenContents = children.map { $0.generateContents(indentationType: indentationType)}
+            .joined()
+        return "\(indentationString)\(contents)\n" + childrenContents
+    }
+
+    private func indentation(level: Int, indentationType: IndentationType) -> String {
+        (0..<level).reduce("") { acc, _ in acc + "\(indentationType.rawValue)" }
+    }
 }
 
 fileprivate func handleChildless<T>(

--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -74,7 +74,7 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
                     results.append(diff)
                 }
                 if !results.isEmpty {
-                    let header = "\(indentation(level: level))Child key \(key.description):\n"
+                    let header = "\(indentation(level: level))Key \(key.description):\n"
                     closure(header + results.joined())
                 }
             }

--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -1,18 +1,55 @@
-//
-//  Difference.swift
-//  Difference
-//
-//  Created by Krzysztof Zablocki on 18.10.2017
-//  Copyright © 2017 Krzysztof Zablocki. All rights reserved.
-//
-
 import Foundation
 
 fileprivate extension String {
     init<T>(dumping object: T) {
         self.init()
         dump(object, to: &self)
+        self = withoutDumpArtifacts
     }
+
+    private var withoutDumpArtifacts: String {
+        self.replacingOccurrences(of: "- ", with: "")
+            .replacingOccurrences(of: "\n", with: "")
+    }
+}
+
+private func enumLabelFromFirstChild(_ mirror: Mirror) -> String? {
+    switch mirror.displayStyle {
+    case .enum: return mirror.children.first?.label
+    default: return nil
+    }
+}
+
+fileprivate extension Mirror {
+    var displayStyleDescriptor: String {
+        switch self.displayStyle {
+        case .enum: return "Enum"
+        default: return "Child"
+        }
+    }
+}
+
+fileprivate func handleChildlessEnum<T>(
+    _ expected: T,
+    _ received: T,
+    _ indentationLevel: Int
+) -> String {
+    let expectedMirror = Mirror(reflecting: expected)
+    let receivedMirror = Mirror(reflecting: received)
+
+    let receivedPrintable: String
+    let expectedPrintable: String
+    if receivedMirror.children.count == 0, expectedMirror.children.count != 0 {
+        receivedPrintable = String(dumping: received)
+        expectedPrintable = enumLabelFromFirstChild(expectedMirror) ?? String(describing: expected)
+    } else if expectedMirror.children.count == 0, receivedMirror.children.count != 0 {
+        receivedPrintable = enumLabelFromFirstChild(receivedMirror) ?? String(describing: received)
+        expectedPrintable = String(dumping: expected)
+    } else {
+        receivedPrintable = String(describing: received)
+        expectedPrintable = String(describing: expected)
+    }
+    return "R7" + generateExpectedReceiveBlock(expectedPrintable, receivedPrintable, indentationLevel)
 }
 
 /// Compares 2 objects and iterates over their differences
@@ -22,26 +59,29 @@ fileprivate extension String {
 ///   - rhs: received object
 ///   - closure: iteration closure
 fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: (_ description: String) -> Void) {
-    let lhsMirror = Mirror(reflecting: expected)
-    let rhsMirror = Mirror(reflecting: received)
+    let expectedMirror = Mirror(reflecting: expected)
+    let receivedMirror = Mirror(reflecting: received)
 
-    guard lhsMirror.children.count != 0, rhsMirror.children.count != 0 else {
+    guard expectedMirror.children.count != 0, receivedMirror.children.count != 0 else {
         if String(dumping: received) != String(dumping: expected) {
-            closure("received: \"\(received)\" expected: \"\(expected)\"\n")
+            closure(handleChildlessEnum(expected, received, level))
         }
         return
     }
 
-    let hasDiffNumOfChildren = lhsMirror.children.count != rhsMirror.children.count
-    switch (lhsMirror.displayStyle, rhsMirror.displayStyle) {
+    let hasDiffNumOfChildren = expectedMirror.children.count != receivedMirror.children.count
+    switch (expectedMirror.displayStyle, receivedMirror.displayStyle) {
     case (.collection?, .collection?) where hasDiffNumOfChildren,
          (.dictionary?, .dictionary?) where hasDiffNumOfChildren,
          (.set?, .set?) where hasDiffNumOfChildren:
-            closure("""
-                different count:
-                \(indentation(level: level))received: \"\(received)\" (\(rhsMirror.children.count))
-                \(indentation(level: level))expected: \"\(expected)\" (\(lhsMirror.children.count))\n
-                """)
+        let expectedPrintable = "(\(expectedMirror.children.count)) \(expected)"
+        let receivedPrintable = "(\(receivedMirror.children.count)) \(received)"
+        let header = "\(indentation(level: level))Different count:\n"
+        closure(
+            header
+                + "R1"
+                + generateExpectedReceiveBlock(expectedPrintable, receivedPrintable, level + 1)
+        )
         return
     case (.dictionary?, .dictionary?):
         if let expectedDict = expected as? Dictionary<AnyHashable, Any>,
@@ -52,7 +92,7 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
                     results.append(diff)
                 }
                 if !results.isEmpty {
-                    closure("child key \(key.description):\n\(indentation(level: max(level + 1, 1)))" + results.joined(separator: "\n\(indentation(level: max(level + 1, 1)))"))
+                    closure("R2 Child key \(key.description):\n\(indentation(level: max(level + 1, 1)))" + results.joined(separator: "\n\(indentation(level: max(level + 1, 1)))"))
                 }
             }
             return
@@ -65,42 +105,70 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
 
             var results = [String]()
             uniqueExpected.forEach { unique in
-                results.append("SetElement missing: \(unique.description)\n")
+                results.append("R3 SetElement missing: \(unique.description)\n")
             }
 
             if !uniqueExpected.isEmpty {
-                closure(results.joined(separator: "\(indentation(level: max(level, 1)))"))
+                closure(results.joined(separator: "\(indentation(level: max(level + 1, 1)))"))
             }
             return
         }
-    case (.enum?, .enum?) where lhsMirror.children.first?.label != rhsMirror.children.first?.label,
-         (.optional?, .optional?) where hasDiffNumOfChildren:
-        closure("received: \"\(received)\" expected: \"\(expected)\"\n")
+    case (.enum?, .enum) where hasDiffNumOfChildren:
+        closure("""
+            R4 Different count:
+            \(indentation(level: level))Received: \(received) (\(receivedMirror.children.count))
+            \(indentation(level: level))Expected: \(expected) (\(expectedMirror.children.count))\n
+            """)
+        return
+    case (.enum?, .enum?) where expectedMirror.children.first?.label != receivedMirror.children.first?.label:
+        let expectedPrintable = expectedMirror.children.first?.label ?? "UNKNOWN"
+        let receivedPrintable = receivedMirror.children.first?.label ?? "UNKNOWN"
+
+        closure("R5" + generateExpectedReceiveBlock(expectedPrintable, receivedPrintable, level))
+        return
+//        closure("\(indentation(level: level))R5 Received: \(received) Expected: \(expected)\n")
+
+//    case (.optional?, .optional?) where hasDiffNumOfChildren:
+
     default:
         break
     }
 
-    let zipped = zip(lhsMirror.children, rhsMirror.children)
+    let zipped = zip(expectedMirror.children, receivedMirror.children)
     zipped.forEach { (lhs, rhs) in
         let leftDump = String(dumping: lhs.value)
         if leftDump != String(dumping: rhs.value) {
-            if let notPrimitive = Mirror(reflecting: lhs.value).displayStyle, notPrimitive != .tuple {
+            if let notPrimitive = Mirror(reflecting: lhs.value).displayStyle/*, notPrimitive != .tuple*/ {
                 var results = [String]()
                 diff(lhs.value, rhs.value, level: level + 1) { diff in
                     results.append(diff)
                 }
                 if !results.isEmpty {
-                    closure("child \(lhs.label ?? ""):\n\(indentation(level: level + 1))" + results.joined(separator: "\(indentation(level: level + 1))"))
+                    closure("R8\(indentation(level: level))\(expectedMirror.displayStyleDescriptor) \(lhs.label ?? ""):\n" + results.joined())
                 }
-            } else {
-                closure("\(lhs.label ?? "") received: \"\(rhs.value)\" expected: \"\(lhs.value)\"\n")
+            } else { // todo maybe remove
+                closure("R9\(expectedMirror.displayStyleDescriptor) \(lhs.label ?? ""):\n" + "R6" + generateExpectedReceiveBlock(String(describing: lhs.value), String(describing: rhs.value), level + 1))
+//                closure("\(lhs.label ?? "") received: \(rhs.value) expected: \(lhs.value)\n")
             }
         }
     }
 }
 
+private func generateExpectedReceiveBlock(
+    _ expected: String,
+    _ received: String,
+    _ indentationLevel: Int
+) -> String {
+    let indentationSpacing = indentation(level: indentationLevel)
+    return """
+    \(indentationSpacing)Received: \(received)
+    \(indentationSpacing)Expected: \(expected)
+    """
+    //"\(indentationSpacing)Received: \(received)\n\(indentationSpacing)Expected: \(expected)\n"
+}
+
 private func indentation(level: Int) -> String {
-    return (0..<level).reduce("") { acc, _ in acc + "\t" }
+    return (0..<level).reduce("") { acc, _ in acc + "|\t" }
 }
 
 /// Builds list of differences between 2 objects
@@ -137,3 +205,8 @@ public func dumpDiff<T: Equatable>(_ expected: T, _ received: T) {
 public func dumpDiff<T>(_ expected: T, _ received: T) {
     diff(expected, received).forEach { print($0) }
 }
+
+// TO CHECK:
+//DONE Enum with different contents
+// Enum with different label
+// Enum with nil, rather than a value

--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -35,7 +35,8 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
     let hasDiffNumOfChildren = lhsMirror.children.count != rhsMirror.children.count
     switch (lhsMirror.displayStyle, rhsMirror.displayStyle) {
     case (.collection?, .collection?) where hasDiffNumOfChildren,
-         (.dictionary?, .dictionary?) where hasDiffNumOfChildren:
+         (.dictionary?, .dictionary?) where hasDiffNumOfChildren,
+         (.set?, .set?) where hasDiffNumOfChildren:
             closure("""
                 different count:
                 \(indentation(level: level))received: \"\(received)\" (\(rhsMirror.children.count))
@@ -53,6 +54,32 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
                 if !results.isEmpty {
                     closure("child key \(key.description):\n\(indentation(level: max(level, 1)))" + results.joined())
                 }
+            }
+            return
+        }
+
+    case (.set?, .set?):
+        if let expectedSet = expected as? Set<AnyHashable>,
+            let receivedSet = received as? Set<AnyHashable> {
+            let uniqueExpected = expectedSet.subtracting(receivedSet)
+            let uniqueReceived = receivedSet.subtracting(expectedSet)
+
+//            let something = Array(uniqueExpected).sorted { (lhs, rhs) -> Bool in
+//                if let lhsComp = lhs as? Comparable {
+//
+//                }
+//            }
+
+
+
+            var results = [String]()
+            zip(uniqueExpected, uniqueReceived).forEach { lhs, rhs in
+                diff(lhs, rhs, level: level + 1) { diff in
+                    results.append("\(indentation(level: max(level, 1)))\(diff)")
+                }
+            }
+            if !results.isEmpty {
+                closure("Set mismatch:\n" + results.joined())
             }
             return
         }

--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -52,7 +52,7 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
                     results.append(diff)
                 }
                 if !results.isEmpty {
-                    closure("child key \(key.description):\n\(indentation(level: max(level, 1)))" + results.joined(separator: "\n\(indentation(level: max(level, 1)))"))
+                    closure("child key \(key.description):\n\(indentation(level: max(level + 1, 1)))" + results.joined(separator: "\n\(indentation(level: max(level + 1, 1)))"))
                 }
             }
             return
@@ -62,20 +62,14 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
         if let expectedSet = expected as? Set<AnyHashable>,
             let receivedSet = received as? Set<AnyHashable> {
             let uniqueExpected = expectedSet.subtracting(receivedSet)
-            let uniqueReceived = receivedSet.subtracting(expectedSet)
 
             var results = [String]()
             uniqueExpected.forEach { unique in
                 results.append("SetElement missing: \(unique.description)\n")
             }
-//            zip(uniqueExpected, uniqueReceived).forEach { lhs, rhs in
-//                diff(lhs, rhs, level: level + 1) { diff in
-//                    results.append("\(indentation(level: max(level, 1)))\(diff)")
-//                }
-//            }
+
             if !uniqueExpected.isEmpty {
-//                closure("ExpectedSet missing:\n" + Array(uniqueExpected).map { $0.description }.joined())
-                closure("ExpectedSet missing:\n\(indentation(level: max(level, 1)))" + results.joined(separator: "\(indentation(level: max(level, 1)))"))
+                closure(results.joined(separator: "\(indentation(level: max(level, 1)))"))
             }
             return
         }
@@ -96,7 +90,7 @@ fileprivate func diff<T>(_ expected: T, _ received: T, level: Int = 0, closure: 
                     results.append(diff)
                 }
                 if !results.isEmpty {
-                    closure("child \(lhs.label ?? ""):\n\(indentation(level: level))" + results.joined(separator: "\(indentation(level: level))"))
+                    closure("child \(lhs.label ?? ""):\n\(indentation(level: level + 1))" + results.joined(separator: "\(indentation(level: level + 1))"))
                 }
             } else {
                 closure("\(lhs.label ?? "") received: \"\(rhs.value)\" expected: \"\(lhs.value)\"\n")

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -82,7 +82,7 @@ private func dumpDiffSurround<T>(_ lhs: T, _ rhs: T) {
 class DifferenceTests: XCTestCase {
 
     func testCanFindRootPrimitiveDifference() {
-//        dumpDiffSurround(2, 3)
+        dumpDiffSurround(2, 3)
         let results = diff(2, 3)
 
         XCTAssertEqual(results.count, 1)
@@ -105,7 +105,7 @@ class DifferenceTests: XCTestCase {
     func testCanFindMultipleDifference() {
         let stub = Person(name: "Adam", age: 30)
 
-//        dumpDiffSurround(truth, stub)
+        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 2)
@@ -182,7 +182,7 @@ class DifferenceTests: XCTestCase {
         let truth = State.loaded([0], "CommonString")
         let stub = State.anotherLoaded([0], "CommonString")
 
-//        dumpDiffSurround(truth, stub)
+        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -108,7 +108,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "address:\n|\tstreet:\n|\t|\tReceived: 2nd Street\n|\t|\tExpected: Times Square\n|\tcounter:\n|\t|\tcounter:\n|\t|\t|\tReceived: 1\n|\t|\t|\tExpected: 2\n")
+        XCTAssertEqual(results.first, "address:\n|\tcounter:\n|\t|\tcounter:\n|\t|\t|\tReceived: 1\n|\t|\t|\tExpected: 2\n|\tstreet:\n|\t|\tReceived: 2nd Street\n|\t|\tExpected: Times Square\n")
 
     }
 
@@ -188,18 +188,12 @@ class DifferenceTests: XCTestCase {
     }
 
     func test_canFindOptionalDifferenceBetweenSomeAndNone() {
-        let truth = Person(petAges: ["Henny": 4, "Jethro": 6])
+        let truth = Person(petAges: ["Henny": 4])
         let stub = Person(petAges: nil)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        let header = "petAges:\n|\tReceived: nil\n|\tExpected: Optional(["
-        let hennyDiff = "\"Henny\": 4"
-        let jethroDiff = "\"Jethro\": 6"
-        let endingDiff = "])\n"
-        let firstPermutation = header + hennyDiff + ", " + jethroDiff + endingDiff
-        let secondPermutation = header + jethroDiff + ", " + hennyDiff + endingDiff
-        XCTAssertTrue(assertEither(expected: (firstPermutation, secondPermutation), received: results.first))
+        XCTAssertEqual(results.first, "petAges:\n|\tReceived: nil\n|\tExpected: Optional([\"Henny\": 4])\n")
     }
 
     func test_canFindDictionaryDifference() {
@@ -211,9 +205,8 @@ class DifferenceTests: XCTestCase {
         let header = "petAges:\n|\tsome:\n"
         let jethroDiff = "|\t|\tKey Jethro:\n|\t|\t|\tsome:\n|\t|\t|\t|\tReceived: 2\n|\t|\t|\t|\tExpected: 6\n"
         let hennyDiff = "|\t|\tKey Henny:\n|\t|\t|\tsome:\n|\t|\t|\t|\tReceived: 1\n|\t|\t|\t|\tExpected: 4\n"
-        let firstPermutation = header + jethroDiff + hennyDiff
         let secondPermutation = header + hennyDiff + jethroDiff
-        XCTAssertTrue(assertEither(expected: (firstPermutation, secondPermutation), received: results.first))
+        XCTAssertEqual(results.first, secondPermutation)
     }
 
     // MARK: Sets
@@ -242,24 +235,6 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        let header = "favoriteFoods:\n|\tsome:\n"
-        let sushiDiff = "|\t|\tMissing: Sushi\n"
-        let pizzaDiff = "|\t|\tMissing: Pizza\n"
-        let firstPermutation = header + sushiDiff + pizzaDiff
-        let secondPermutation = header + pizzaDiff + sushiDiff
-        XCTAssertTrue(assertEither(expected: (firstPermutation, secondPermutation), received: results.first))
-    }
-}
-
-private func assertEither<T: Equatable>(
-    expected: (T, T),
-    received: T
-) -> Bool {
-    if expected.0 == received {
-        return true
-    } else if expected.1 == received {
-        return true
-    } else {
-        return false
+        XCTAssertEqual(results.first, "favoriteFoods:\n|\tsome:\n|\t|\tMissing: Pizza\n|\t|\tMissing: Sushi\n")
     }
 }

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -122,6 +122,26 @@ class DifferenceTests: XCTestCase {
         XCTAssertEqual(results.first, "received: \"nil\" expected: \"Optional([\"A\": \"B\"])\"\n")
     }
 
+    func test_canFindDictionaryDifference() {
+        let results = diff(
+            [
+                "a": 1,
+                "b": 2,
+                "c": 3,
+                "d": 4,
+            ],
+            [
+                "a": 1,
+                "b": 2,
+                "c": 3,
+                "d": 0,
+            ]
+        )
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first, "child key d:\n\tsome received: \"0\" expected: \"4\"\n")
+    }
+
     static var allTests = [
         ("testCanFindRootPrimitiveDifference", testCanFindRootPrimitiveDifference),
         ("testCanFindPrimitiveDifference", testCanFindPrimitiveDifference),
@@ -130,6 +150,7 @@ class DifferenceTests: XCTestCase {
         ("test_canFindCollectionCountDifference", test_canFindCollectionCountDifference),
         ("test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical", test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical),
         ("test_canFindDictionaryCountDifference", test_canFindDictionaryCountDifference),
-        ("test_canFindOptionalDifferenceBetweenSomeAndNone", test_canFindOptionalDifferenceBetweenSomeAndNone)
+        ("test_canFindOptionalDifferenceBetweenSomeAndNone", test_canFindOptionalDifferenceBetweenSomeAndNone),
+        ("test_canFindDictionaryDifference", test_canFindDictionaryDifference)
     ]
 }

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -10,21 +10,21 @@ import Foundation
 import XCTest
 import Difference
 
-fileprivate struct Person {
+fileprivate struct Person: Equatable {
     let name: String
     let age: Int
 
-    struct Address {
+    struct Address: Equatable {
         let street: String
         let postCode: String
 
-        struct ComplexCounter {
+        struct ComplexCounter: Equatable {
             let counter: Int
         }
         let counter: ComplexCounter
     }
     
-    struct Pet {
+    struct Pet: Equatable {
         let name: String
     }
 
@@ -55,6 +55,7 @@ class DifferenceTests: XCTestCase {
 
         XCTAssertEqual(results.count, 1)
         XCTAssertEqual(results.first, "age received: \"30\" expected: \"29\"\n")
+
     }
 
     func testCanFindMultipleDifference() {
@@ -75,21 +76,21 @@ class DifferenceTests: XCTestCase {
         XCTAssertEqual(results.count, 1)
         XCTAssertEqual(results.first, "child address:\nstreet received: \"2nd Street\" expected: \"Times Square\"\nchild counter:\n\tcounter received: \"1\" expected: \"2\"\n")
     }
-    
+
     func testCanGiveDescriptionForOptionalOnLeftSide() {
         let truth = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil)
-        
+
         let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: .init(name: "Fluffy"))
-        
+
         let results = diff(truth, stub)
         XCTAssertEqual(results.count, 1)
     }
-    
+
     func testCanGiveDescriptionForOptionalOnRightSide() {
         let truth = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: .init(name: "Fluffy"))
-        
+
         let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil)
-        
+
         let results = diff(truth, stub)
         XCTAssertEqual(results.count, 1)
     }
@@ -126,7 +127,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(
             [
                 "a": 1,
-                "b": 2,
+                "b": 3,
                 "c": 3,
                 "d": 4,
             ],
@@ -138,19 +139,33 @@ class DifferenceTests: XCTestCase {
             ]
         )
 
+        // TODO: Should results.count be 2?
         XCTAssertEqual(results.count, 1)
         XCTAssertEqual(results.first, "child key d:\n\tsome received: \"0\" expected: \"4\"\n")
     }
 
-    static var allTests = [
-        ("testCanFindRootPrimitiveDifference", testCanFindRootPrimitiveDifference),
-        ("testCanFindPrimitiveDifference", testCanFindPrimitiveDifference),
-        ("testCanFindMultipleDifference", testCanFindMultipleDifference),
-        ("testCanFindComplexDifference", testCanFindComplexDifference),
-        ("test_canFindCollectionCountDifference", test_canFindCollectionCountDifference),
-        ("test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical", test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical),
-        ("test_canFindDictionaryCountDifference", test_canFindDictionaryCountDifference),
-        ("test_canFindOptionalDifferenceBetweenSomeAndNone", test_canFindOptionalDifferenceBetweenSomeAndNone),
-        ("test_canFindDictionaryDifference", test_canFindDictionaryDifference)
-    ]
+    func test_set() {
+        (0..<1000).forEach { _ in
+        let expected: Set<Int> = [1, 2, 3, 4, 5]
+        let actual: Set<Int> = [7, 6, 5, 4, 3]
+
+        let results = diff(expected, actual)
+
+        XCTAssertEqual(results.count, 1)
+            // Need to figure out how to get consistent ordering of a set in the result. Alternately, reduce this test to only 1 diff.
+        XCTAssertEqual(results.first!, "Set mismatch:\n\tvalue received: \"7\" expected: \"2\"\n\tvalue received: \"6\" expected: \"1\"\n" )
+        }
+    }
+//
+//    static var allTests = [
+//        ("testCanFindRootPrimitiveDifference", testCanFindRootPrimitiveDifference),
+//        ("testCanFindPrimitiveDifference", testCanFindPrimitiveDifference),
+//        ("testCanFindMultipleDifference", testCanFindMultipleDifference),
+//        ("testCanFindComplexDifference", testCanFindComplexDifference),
+//        ("test_canFindCollectionCountDifference", test_canFindCollectionCountDifference),
+//        ("test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical", test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical),
+//        ("test_canFindDictionaryCountDifference", test_canFindDictionaryCountDifference),
+//        ("test_canFindOptionalDifferenceBetweenSomeAndNone", test_canFindOptionalDifferenceBetweenSomeAndNone),
+//        ("test_canFindDictionaryDifference", test_canFindDictionaryDifference)
+//    ]
 }

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -13,24 +13,58 @@ import Difference
 fileprivate struct Person: Equatable {
     let name: String
     let age: Int
+    let address: Address
+    let pet: Pet?
+    let petAges: [String: Int]?
+    let favoriteFoods: Set<String>?
+
+    init(
+        name: String = "Krzysztof",
+        age: Int = 29,
+        address: Address = .init(),
+        pet: Pet? = .init(),
+        petAges: [String: Int]? = nil,
+        favoriteFoods: Set<String>? = nil
+    ) {
+        self.name = name
+        self.age = age
+        self.address = address
+        self.pet = pet
+        self.petAges = petAges
+        self.favoriteFoods = favoriteFoods
+    }
 
     struct Address: Equatable {
         let street: String
         let postCode: String
+        let counter: ComplexCounter
+
+        init(
+            street: String = "Times Square",
+            postCode: String = "00-1000",
+            counter: ComplexCounter = .init()
+        ) {
+            self.street = street
+            self.postCode = postCode
+            self.counter = counter
+        }
 
         struct ComplexCounter: Equatable {
             let counter: Int
+
+            init(counter: Int = 2) {
+                self.counter = counter
+            }
         }
-        let counter: ComplexCounter
-    }
-    
-    struct Pet: Equatable {
-        let name: String
     }
 
-    let address: Address
-    let pet: Pet?
-    let petAges: [String: Int]
+    struct Pet: Equatable {
+        let name: String
+
+        init(name: String = "Fluffy") {
+            self.name = name
+        }
+    }
 }
 
 private enum State {
@@ -54,10 +88,10 @@ class DifferenceTests: XCTestCase {
         XCTAssertEqual(results.first, "R7Received: 3\nExpected: 2\n")
     }
 
-    fileprivate let truth = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil, petAges: [:])
+    fileprivate let truth = Person()
 
     func testCanFindPrimitiveDifference() {
-        let stub = Person(name: "Krzysztof", age: 30, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil, petAges: [:])
+        let stub = Person(age: 30)
 
 //        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
@@ -68,7 +102,7 @@ class DifferenceTests: XCTestCase {
     }
 
     func testCanFindMultipleDifference() {
-        let stub = Person(name: "Adam", age: 30, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil, petAges: [:])
+        let stub = Person(name: "Adam", age: 30)
 
 //        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
@@ -79,7 +113,7 @@ class DifferenceTests: XCTestCase {
     }
 
     func testCanFindComplexDifference() {
-        let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "2nd Street", postCode: "00-1000", counter: .init(counter: 1)), pet: nil, petAges: [:])
+        let stub = Person(address: Person.Address(street: "2nd Street", counter: .init(counter: 1)))
 
 //        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
@@ -90,9 +124,9 @@ class DifferenceTests: XCTestCase {
     }
 
     func testCanGiveDescriptionForOptionalOnLeftSide() {
-        let truth = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil, petAges: [:])
+        let truth = Person(pet: nil)
 
-        let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: .init(name: "Fluffy"), petAges: [:])
+        let stub = Person()
 
 //        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
@@ -100,9 +134,9 @@ class DifferenceTests: XCTestCase {
     }
 
     func testCanGiveDescriptionForOptionalOnRightSide() {
-        let truth = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: .init(name: "Fluffy"), petAges: [:])
+        let truth = Person()
 
-        let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil, petAges: [:])
+        let stub = Person(pet: nil)
 
 //        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
@@ -110,7 +144,7 @@ class DifferenceTests: XCTestCase {
     }
 
     func test_canFindCollectionCountDifference() {
-        dumpDiffSurround([1], [1, 3])
+//        dumpDiffSurround([1], [1, 3])
 
         let results = diff([1], [1, 3])
 
@@ -141,69 +175,64 @@ class DifferenceTests: XCTestCase {
     }
 
     func test_canFindDictionaryCountDifference() {
-        let truth = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: .init(name: "Fluffy"), petAges: ["Max": 4, "Jethro": 6])
+        let truth = Person(petAges: ["Henny": 4, "Jethro": 6])
 
-        let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil, petAges: ["Max": 1, "Jethro": 2])
+        let stub = Person(petAges: ["Henny": 1])
 
-        dumpDiffSurround(truth, stub)
+//        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "received: \"[:]\" expected: \"[\"A\": \"B\"]\"\n")
+        XCTAssertEqual(results.first, "R8Child petAges:\nR8|\tChild some:\nR10|\t|\tDifferent count:\nR1|\t|\t|\tReceived: (1) [\"Henny\": 1]\n|\t|\t|\tExpected: (2) [\"Henny\": 4, \"Jethro\": 6]\n")
     }
 
-//    func test_canFindDictionaryCountDifference_complex() {
-//        let truth = ["A": "B"]
-//        let stub = Dictionary<String, String>()
-//
-//        dumpDiffSurround(truth, stub)
-//        let results = diff(truth, stub)
-//
-//        XCTAssertEqual(results.count, 1)
-//        XCTAssertEqual(results.first, "received: \"[:]\" expected: \"[\"A\": \"B\"]\"\n")
-//    }
+    func test_canFindOptionalDifferenceBetweenSomeAndNone() {
+        let truth = Person(petAges: ["Henny": 4, "Jethro": 6])
 
-//    func test_canFindOptionalDifferenceBetweenSomeAndNone() {
-//        let results = diff(["A": "B"], nil)
-//
-//        XCTAssertEqual(results.count, 1)
-//        XCTAssertEqual(results.first, "received: \"nil\" expected: \"Optional([\"A\": \"B\"])\"\n")
-//    }
-//
-//    func test_canFindDictionaryDifference() {
-//        let results = diff(
-//            [
-//                "a": 1,
-//                "b": 3,
-//                "c": 3,
-//                "d": 4,
-//            ],
-//            [
-//                "a": 1,
-//                "b": 2,
-//                "c": 3,
-//                "d": 0,
-//            ]
-//        )
-//
-//        // TODO: Should results.count be 2?
-//        XCTAssertEqual(results.count, 2)
-//        XCTAssertEqual(results.first, "")
-//    }
-//
-//    func test_set() {
-//        (0..<1000).forEach { _ in
-//            let expected: Set<Int> = [1, 2, 3, 4, 5]
-//            let actual: Set<Int> = [7, 6, 5, 4, 3]
-//
-//            let results = diff(expected, actual)
-//
-//            XCTAssertEqual(results.count, 1)
-//                // Need to figure out how to get consistent ordering of a set in the result. Alternately, reduce this test to only 1 diff.
-//            XCTAssertEqual(results.first!, "Set mismatch:\n\tvalue received: \"7\" expected: \"2\"\n\tvalue received: \"6\" expected: \"1\"\n" )
-//        }
-//    }
-//
+        let stub = Person(petAges: nil)
+
+//        dumpDiffSurround(truth, stub)
+        let results = diff(truth, stub)
+
+        XCTAssertEqual(results.count, 1)
+        let header = "R8Child petAges:\nR7|\tReceived: nil\n|\tExpected: Optional(["
+        let hennyDiff = "\"Henny\": 4"
+        let jethroDiff = "\"Jethro\": 6"
+        let endingDiff = "])\n"
+        let firstPermutation = header + hennyDiff + ", " + jethroDiff + endingDiff
+        let secondPermutation = header + jethroDiff + ", " + hennyDiff + endingDiff
+        XCTAssertTrue(assertEither(expected: (firstPermutation, secondPermutation), received: results.first))
+    }
+
+    func test_canFindDictionaryDifference() {
+        let truth = Person(petAges: ["Henny": 4, "Jethro": 6])
+
+        let stub = Person(petAges: ["Henny": 1, "Jethro": 2])
+
+//        dumpDiffSurround(truth, stub)
+        let results = diff(truth, stub)
+
+        XCTAssertEqual(results.count, 1)
+        let header = "R8Child petAges:\nR8|\tChild some:\n"
+        let jethroDiff = "R2|\t|\tChild key Jethro:\nR9|\t|\t|\tChild some:\nR6|\t|\t|\t|\tReceived: 2\n|\t|\t|\t|\tExpected: 6\n"
+        let hennyDiff = "R2|\t|\tChild key Henny:\nR9|\t|\t|\tChild some:\nR6|\t|\t|\t|\tReceived: 1\n|\t|\t|\t|\tExpected: 4\n"
+        let firstPermutation = header + jethroDiff + hennyDiff
+        let secondPermutation = header + hennyDiff + jethroDiff
+        XCTAssertTrue(assertEither(expected: (firstPermutation, secondPermutation), received: results.first))
+    }
+
+    func test_canFindSetCountDifferent() {
+        let truth = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil, petAges: ["Henny": 4, "Jethro": 6])
+
+        let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil, petAges: ["Henny": 1])
+
+//        dumpDiffSurround(truth, stub)
+        let results = diff(truth, stub)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first, "R8Child petAges:\nR8|\tChild some:\nR10|\t|\tDifferent count:\nR1|\t|\t|\tReceived: (1) [\"Henny\": 1]\n|\t|\t|\tExpected: (2) [\"Henny\": 4, \"Jethro\": 6]\n")
+    }
+
 //    func test_inner_set() {
 //        let expectedAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [1, 2, 3, 4, 5], dictionaryOfInts: ["a":1])
 //        let actualAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [3, 4, 5, 6, 7], dictionaryOfInts: ["a":2])
@@ -277,6 +306,19 @@ class DifferenceTests: XCTestCase {
 //        print(results.joined(separator: "\n"))
 //        print("@@@@@@@@@@@@")
 //    }
+}
+
+private func assertEither<T: Equatable>(
+    expected: (T, T),
+    received: T
+) -> Bool {
+    if expected.0 == received {
+        return true
+    } else if expected.1 == received {
+        return true
+    } else {
+        return false
+    }
 }
 
 fileprivate struct Container1: Equatable {

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -98,7 +98,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "Child age:\n|\tReceived: 30\n|\tExpected: 29\n")
+        XCTAssertEqual(results.first, "age:\n|\tReceived: 30\n|\tExpected: 29\n")
 
     }
 
@@ -109,8 +109,8 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 2)
-        XCTAssertEqual(results.first, "Child name:\n|\tReceived: Adam\n|\tExpected: Krzysztof\n")
-        XCTAssertEqual(results.last, "Child age:\n|\tReceived: 30\n|\tExpected: 29\n")
+        XCTAssertEqual(results.first, "name:\n|\tReceived: Adam\n|\tExpected: Krzysztof\n")
+        XCTAssertEqual(results.last, "age:\n|\tReceived: 30\n|\tExpected: 29\n")
     }
 
     func testCanFindComplexDifference() {
@@ -120,7 +120,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "Child address:\n|\tChild street:\n|\t|\tReceived: 2nd Street\n|\t|\tExpected: Times Square\n|\tChild counter:\n|\t|\tChild counter:\n|\t|\t|\tReceived: 1\n|\t|\t|\tExpected: 2\n")
+        XCTAssertEqual(results.first, "address:\n|\tstreet:\n|\t|\tReceived: 2nd Street\n|\t|\tExpected: Times Square\n|\tcounter:\n|\t|\tcounter:\n|\t|\t|\tReceived: 1\n|\t|\t|\tExpected: 2\n")
 
     }
 
@@ -154,14 +154,14 @@ class DifferenceTests: XCTestCase {
     }
 
     func test_canFindCollectionCountDifference_complex() {
-        let truth = State.loaded([1, 2], "truth")
-        let stub = State.loaded([], "stub")
+        let truth = State.loaded([1, 2], "truthString")
+        let stub = State.loaded([], "stubString")
         dumpDiffSurround(truth, stub)
 
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "Enum loaded:\n|\tChild .0:\n|\t|\tDifferent count:\n|\t|\t|\tReceived: (0) []\n|\t|\t|\tExpected: (2) [1, 2]\n|\tChild .1:\n|\t|\tReceived: stub\n|\t|\tExpected: truth\n")
+        XCTAssertEqual(results.first, "Enum loaded:\n|\t.0:\n|\t|\tDifferent count:\n|\t|\t|\tReceived: (0) []\n|\t|\t|\tExpected: (2) [1, 2]\n|\t.1:\n|\t|\tReceived: stubString\n|\t|\tExpected: truthString\n")
     }
 
     func test_labelsArrayElementsInDiff() {
@@ -172,8 +172,8 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 2)
-        XCTAssertEqual(results.first, "Collection[0]:\n|\tChild name:\n|\t|\tReceived: John\n|\t|\tExpected: Krzysztof\n")
-        XCTAssertEqual(results.last, "Collection[1]:\n|\tChild name:\n|\t|\tReceived: Krzysztof\n|\t|\tExpected: John\n")
+        XCTAssertEqual(results.first, "Collection[0]:\n|\tname:\n|\t|\tReceived: John\n|\t|\tExpected: Krzysztof\n")
+        XCTAssertEqual(results.last, "Collection[1]:\n|\tname:\n|\t|\tReceived: Krzysztof\n|\t|\tExpected: John\n")
     }
 
     // MARK: Enums
@@ -210,7 +210,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "Child petAges:\n|\tChild some:\n|\t|\tDifferent count:\n|\t|\t|\tReceived: (0) [:]\n|\t|\t|\tExpected: (1) [\"Henny\": 4]\n")
+        XCTAssertEqual(results.first, "petAges:\n|\tsome:\n|\t|\tDifferent count:\n|\t|\t|\tReceived: (0) [:]\n|\t|\t|\tExpected: (1) [\"Henny\": 4]\n")
     }
 
     func test_canFindOptionalDifferenceBetweenSomeAndNone() {
@@ -221,7 +221,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        let header = "Child petAges:\n|\tReceived: nil\n|\tExpected: Optional(["
+        let header = "petAges:\n|\tReceived: nil\n|\tExpected: Optional(["
         let hennyDiff = "\"Henny\": 4"
         let jethroDiff = "\"Jethro\": 6"
         let endingDiff = "])\n"
@@ -238,9 +238,9 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        let header = "Child petAges:\n|\tChild some:\n"
-        let jethroDiff = "|\t|\tChild key Jethro:\n|\t|\t|\tChild some:\n|\t|\t|\t|\tReceived: 2\n|\t|\t|\t|\tExpected: 6\n"
-        let hennyDiff = "|\t|\tChild key Henny:\n|\t|\t|\tChild some:\n|\t|\t|\t|\tReceived: 1\n|\t|\t|\t|\tExpected: 4\n"
+        let header = "petAges:\n|\tsome:\n"
+        let jethroDiff = "|\t|\tKey Jethro:\n|\t|\t|\tsome:\n|\t|\t|\t|\tReceived: 2\n|\t|\t|\t|\tExpected: 6\n"
+        let hennyDiff = "|\t|\tKey Henny:\n|\t|\t|\tsome:\n|\t|\t|\t|\tReceived: 1\n|\t|\t|\t|\tExpected: 4\n"
         let firstPermutation = header + jethroDiff + hennyDiff
         let secondPermutation = header + hennyDiff + jethroDiff
         XCTAssertTrue(assertEither(expected: (firstPermutation, secondPermutation), received: results.first))
@@ -256,7 +256,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "Child favoriteFoods:\n|\tChild some:\n|\t|\tDifferent count:\n|\t|\t|\tReceived: (1) [\"Oysters\"]\n|\t|\t|\tExpected: (0) []\n")
+        XCTAssertEqual(results.first, "favoriteFoods:\n|\tsome:\n|\t|\tDifferent count:\n|\t|\t|\tReceived: (1) [\"Oysters\"]\n|\t|\t|\tExpected: (0) []\n")
     }
 
     func test_canFindOptionalSetDifferenceBetweenSomeAndNone() {
@@ -267,7 +267,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "Child favoriteFoods:\n|\tReceived: nil\n|\tExpected: Optional(Set([\"Oysters\"]))\n")
+        XCTAssertEqual(results.first, "favoriteFoods:\n|\tReceived: nil\n|\tExpected: Optional(Set([\"Oysters\"]))\n")
     }
 
     func test_canFindSetDifference() {
@@ -278,7 +278,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        let header = "Child favoriteFoods:\n|\tChild some:\n"
+        let header = "favoriteFoods:\n|\tsome:\n"
         let sushiDiff = "|\t|\tMissing: Sushi\n"
         let pizzaDiff = "|\t|\tMissing: Pizza\n"
         let firstPermutation = header + sushiDiff + pizzaDiff

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -37,13 +37,20 @@ private enum State {
     case anotherLoaded([Int])
 }
 
+private func dumpDiffSurround<T: Equatable>(_ lhs: T, _ rhs: T) {
+    print("====START DIFF====")
+    dumpDiff(lhs, rhs)
+    print("=====END DIFF=====")
+}
+
 class DifferenceTests: XCTestCase {
 
     func testCanFindRootPrimitiveDifference() {
+//        dumpDiffSurround(2, 3)
         let results = diff(2, 3)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "received: \"3\" expected: \"2\"\n")
+        XCTAssertEqual(results.first, "R7Received: 3\nExpected: 2")
     }
 
     fileprivate let truth = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil)
@@ -51,199 +58,189 @@ class DifferenceTests: XCTestCase {
     func testCanFindPrimitiveDifference() {
         let stub = Person(name: "Krzysztof", age: 30, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil)
 
+//        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "age received: \"30\" expected: \"29\"\n")
+        XCTAssertEqual(results.first, "R9Child age:\nR6|\tReceived: 30\n|\tExpected: 29")
 
     }
 
     func testCanFindMultipleDifference() {
         let stub = Person(name: "Adam", age: 30, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil)
 
+//        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 2)
-        XCTAssertEqual(results.first, "name received: \"Adam\" expected: \"Krzysztof\"\n")
-        XCTAssertEqual(results.last, "age received: \"30\" expected: \"29\"\n")
+        XCTAssertEqual(results.first, "R9Child name:\nR6|\tReceived: Adam\n|\tExpected: Krzysztof")
+        XCTAssertEqual(results.last, "R9Child age:\nR6|\tReceived: 30\n|\tExpected: 29")
     }
 
     func testCanFindComplexDifference() {
         let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "2nd Street", postCode: "00-1000", counter: .init(counter: 1)), pet: nil)
 
+        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
-        dumpDiff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
         XCTAssertEqual(results.first, "child address:\nstreet received: \"2nd Street\" expected: \"Times Square\"\nchild counter:\n\tcounter received: \"1\" expected: \"2\"\n")
 
     }
-
-    func testCanGiveDescriptionForOptionalOnLeftSide() {
-        let truth = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil)
-
-        let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: .init(name: "Fluffy"))
-
-        let results = diff(truth, stub)
-        XCTAssertEqual(results.count, 1)
-    }
-
-    func testCanGiveDescriptionForOptionalOnRightSide() {
-        let truth = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: .init(name: "Fluffy"))
-
-        let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil)
-
-        let results = diff(truth, stub)
-        XCTAssertEqual(results.count, 1)
-    }
-
-    func test_canFindCollectionCountDifference() {
-        let results = diff([1], [1, 3])
-
-        XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "different count:\nreceived: \"[1, 3]\" (2)\nexpected: \"[1]\" (1)\n")
-    }
-
-    func test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical() {
-        let results = diff(State.loaded([0]), State.anotherLoaded([0]))
-
-        XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "received: \"anotherLoaded([0])\" expected: \"loaded([0])\"\n")
-    }
-
-    func test_canFindDictionaryCountDifference() {
-        let results = diff(["A": "B"], [:])
-
-        XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "received: \"[:]\" expected: \"[\"A\": \"B\"]\"\n")
-    }
-
-    func test_canFindOptionalDifferenceBetweenSomeAndNone() {
-        let results = diff(["A": "B"], nil)
-
-        XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "received: \"nil\" expected: \"Optional([\"A\": \"B\"])\"\n")
-    }
-
-    func test_canFindDictionaryDifference() {
-        let results = diff(
-            [
-                "a": 1,
-                "b": 3,
-                "c": 3,
-                "d": 4,
-            ],
-            [
-                "a": 1,
-                "b": 2,
-                "c": 3,
-                "d": 0,
-            ]
-        )
-
-        // TODO: Should results.count be 2?
-        XCTAssertEqual(results.count, 2)
-        XCTAssertEqual(results.first, "")
-    }
-
-    func test_set() {
-        (0..<1000).forEach { _ in
-            let expected: Set<Int> = [1, 2, 3, 4, 5]
-            let actual: Set<Int> = [7, 6, 5, 4, 3]
-
-            let results = diff(expected, actual)
-
-            XCTAssertEqual(results.count, 1)
-                // Need to figure out how to get consistent ordering of a set in the result. Alternately, reduce this test to only 1 diff.
-            XCTAssertEqual(results.first!, "Set mismatch:\n\tvalue received: \"7\" expected: \"2\"\n\tvalue received: \"6\" expected: \"1\"\n" )
-        }
-    }
-
-    func test_inner_set() {
-        let expectedAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [1, 2, 3, 4, 5], dictionaryOfInts: ["a":1])
-        let actualAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [3, 4, 5, 6, 7], dictionaryOfInts: ["a":2])
-
-        let newPersonExpected = NewPerson(name: "Krzysztof", age: 29, address: expectedAddress, secondAddress: expectedAddress, pet: nil)
-        let newPersonActual = NewPerson(name: "Krzysztof", age: 29, address: actualAddress, secondAddress: actualAddress, pet: nil)
-
-        let results = diff(newPersonExpected, newPersonActual)
-        dumpDiff(newPersonExpected, newPersonActual)
-
-        XCTAssertEqual(results.first!, "" )
-        print("@@@@@@@@@@@@")
-        print(results.first!)
-        print("@@@@@@@@@@@@")
-     }
-
-    func test_inner_dict() {
-        let expectedDicts = [
-            "a": 1,
-            "b": 3,
-            "c": 3,
-            "d": 4,
-        ]
-        let actualDicts = [
-            "a": 1,
-            "b": 2,
-            "c": 6,
-            "d": 0,
-        ]
-
-        let expectedAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [], dictionaryOfInts: expectedDicts)
-        let actualAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [], dictionaryOfInts: actualDicts)
-
-        let newPersonExpected = NewPerson(name: "Krzysztof", age: 29, address: expectedAddress, secondAddress: expectedAddress, pet: nil)
-        let newPersonActual = NewPerson(name: "Krzysztof", age: 29, address: actualAddress, secondAddress: actualAddress, pet: nil)
-
-        let results = diff(newPersonExpected, newPersonActual)
-
-        dumpDiff(newPersonExpected, newPersonActual)
-        XCTAssertEqual(results.first!, "" )
-        print(results.joined(separator: "\n"))
-
-     }
-
-    func test_multiple_child_failures() {
-        let expectedContainer = Container1(
-            topValue: 1,
-            container2: .init(
-                value: 2,
-                container3: .init(
-                    value: 3,
-                    container4: .init(value: 4)
-                )
-            )
-        )
-
-        let actualContainer = Container1(
-            topValue: -1,
-            container2: .init(
-                value: -2,
-                container3: .init(
-                    value: -3,
-                    container4: .init(value: -4)
-                )
-            )
-        )
-
-        let results = diff(expectedContainer, actualContainer)
-
-        print("@@@@@@@@@@@@")
-        print(results.joined(separator: "\n"))
-        print("@@@@@@@@@@@@")
-    }
 //
-//    static var allTests = [
-//        ("testCanFindRootPrimitiveDifference", testCanFindRootPrimitiveDifference),
-//        ("testCanFindPrimitiveDifference", testCanFindPrimitiveDifference),
-//        ("testCanFindMultipleDifference", testCanFindMultipleDifference),
-//        ("testCanFindComplexDifference", testCanFindComplexDifference),
-//        ("test_canFindCollectionCountDifference", test_canFindCollectionCountDifference),
-//        ("test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical", test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical),
-//        ("test_canFindDictionaryCountDifference", test_canFindDictionaryCountDifference),
-//        ("test_canFindOptionalDifferenceBetweenSomeAndNone", test_canFindOptionalDifferenceBetweenSomeAndNone),
-//        ("test_canFindDictionaryDifference", test_canFindDictionaryDifference)
-//    ]
+//    func testCanGiveDescriptionForOptionalOnLeftSide() {
+//        let truth = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil)
+//
+//        let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: .init(name: "Fluffy"))
+//
+//        let results = diff(truth, stub)
+//        XCTAssertEqual(results.count, 1)
+//    }
+//
+//    func testCanGiveDescriptionForOptionalOnRightSide() {
+//        let truth = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: .init(name: "Fluffy"))
+//
+//        let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2)), pet: nil)
+//
+//        let results = diff(truth, stub)
+//        XCTAssertEqual(results.count, 1)
+//    }
+
+//    func test_canFindCollectionCountDifference() {
+//        let results = diff([1], [1, 3])
+//
+//        XCTAssertEqual(results.count, 1)
+//        XCTAssertEqual(results.first, "different count:\nreceived: \"[1, 3]\" (2)\nexpected: \"[1]\" (1)\n")
+//    }
+//
+//    func test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical() {
+//        let results = diff(State.loaded([0]), State.anotherLoaded([0]))
+//
+//        XCTAssertEqual(results.count, 1)
+//        XCTAssertEqual(results.first, "received: \"anotherLoaded([0])\" expected: \"loaded([0])\"\n")
+//    }
+//
+//    func test_canFindDictionaryCountDifference() {
+//        let results = diff(["A": "B"], [:])
+//
+//        XCTAssertEqual(results.count, 1)
+//        XCTAssertEqual(results.first, "received: \"[:]\" expected: \"[\"A\": \"B\"]\"\n")
+//    }
+//
+//    func test_canFindOptionalDifferenceBetweenSomeAndNone() {
+//        let results = diff(["A": "B"], nil)
+//
+//        XCTAssertEqual(results.count, 1)
+//        XCTAssertEqual(results.first, "received: \"nil\" expected: \"Optional([\"A\": \"B\"])\"\n")
+//    }
+//
+//    func test_canFindDictionaryDifference() {
+//        let results = diff(
+//            [
+//                "a": 1,
+//                "b": 3,
+//                "c": 3,
+//                "d": 4,
+//            ],
+//            [
+//                "a": 1,
+//                "b": 2,
+//                "c": 3,
+//                "d": 0,
+//            ]
+//        )
+//
+//        // TODO: Should results.count be 2?
+//        XCTAssertEqual(results.count, 2)
+//        XCTAssertEqual(results.first, "")
+//    }
+//
+//    func test_set() {
+//        (0..<1000).forEach { _ in
+//            let expected: Set<Int> = [1, 2, 3, 4, 5]
+//            let actual: Set<Int> = [7, 6, 5, 4, 3]
+//
+//            let results = diff(expected, actual)
+//
+//            XCTAssertEqual(results.count, 1)
+//                // Need to figure out how to get consistent ordering of a set in the result. Alternately, reduce this test to only 1 diff.
+//            XCTAssertEqual(results.first!, "Set mismatch:\n\tvalue received: \"7\" expected: \"2\"\n\tvalue received: \"6\" expected: \"1\"\n" )
+//        }
+//    }
+//
+//    func test_inner_set() {
+//        let expectedAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [1, 2, 3, 4, 5], dictionaryOfInts: ["a":1])
+//        let actualAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [3, 4, 5, 6, 7], dictionaryOfInts: ["a":2])
+//
+//        let newPersonExpected = NewPerson(name: "Krzysztof", age: 29, address: expectedAddress, secondAddress: expectedAddress, pet: nil)
+//        let newPersonActual = NewPerson(name: "Krzysztof", age: 29, address: actualAddress, secondAddress: actualAddress, pet: nil)
+//
+//        let results = diff(newPersonExpected, newPersonActual)
+//        dumpDiff(newPersonExpected, newPersonActual)
+//
+//        XCTAssertEqual(results.first!, "" )
+//        print("@@@@@@@@@@@@")
+//        print(results.first!)
+//        print("@@@@@@@@@@@@")
+//     }
+//
+//    func test_inner_dict() {
+//        let expectedDicts = [
+//            "a": 1,
+//            "b": 3,
+//            "c": 3,
+//            "d": 4,
+//        ]
+//        let actualDicts = [
+//            "a": 1,
+//            "b": 2,
+//            "c": 6,
+//            "d": 0,
+//        ]
+//
+//        let expectedAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [], dictionaryOfInts: expectedDicts)
+//        let actualAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [], dictionaryOfInts: actualDicts)
+//
+//        let newPersonExpected = NewPerson(name: "Krzysztof", age: 29, address: expectedAddress, secondAddress: expectedAddress, pet: nil)
+//        let newPersonActual = NewPerson(name: "Krzysztof", age: 29, address: actualAddress, secondAddress: actualAddress, pet: nil)
+//
+//        let results = diff(newPersonExpected, newPersonActual)
+//
+//        dumpDiff(newPersonExpected, newPersonActual)
+//        XCTAssertEqual(results.first!, "" )
+//        print(results.joined(separator: "\n"))
+//
+//     }
+//
+//    func test_multiple_child_failures() {
+//        let expectedContainer = Container1(
+//            topValue: 1,
+//            container2: .init(
+//                value: 2,
+//                container3: .init(
+//                    value: 3,
+//                    container4: .init(value: 4)
+//                )
+//            )
+//        )
+//
+//        let actualContainer = Container1(
+//            topValue: -1,
+//            container2: .init(
+//                value: -2,
+//                container3: .init(
+//                    value: -3,
+//                    container4: .init(value: -4)
+//                )
+//            )
+//        )
+//
+//        let results = diff(expectedContainer, actualContainer)
+//
+//        print("@@@@@@@@@@@@")
+//        print(results.joined(separator: "\n"))
+//        print("@@@@@@@@@@@@")
+//    }
 }
 
 fileprivate struct Container1: Equatable {

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -72,9 +72,11 @@ class DifferenceTests: XCTestCase {
         let stub = Person(name: "Krzysztof", age: 29, address: Person.Address(street: "2nd Street", postCode: "00-1000", counter: .init(counter: 1)), pet: nil)
 
         let results = diff(truth, stub)
+        dumpDiff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
         XCTAssertEqual(results.first, "child address:\nstreet received: \"2nd Street\" expected: \"Times Square\"\nchild counter:\n\tcounter received: \"1\" expected: \"2\"\n")
+
     }
 
     func testCanGiveDescriptionForOptionalOnLeftSide() {
@@ -158,13 +160,14 @@ class DifferenceTests: XCTestCase {
     }
 
     func test_inner_set() {
-        let expectedAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [1, 2, 3, 4, 5], dictionaryOfInts: [:])
-        let actualAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [3, 4, 5, 6, 7], dictionaryOfInts: [:])
+        let expectedAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [1, 2, 3, 4, 5], dictionaryOfInts: ["a":1])
+        let actualAddress = NewPerson.Address(street: "Times Square", postCode: "00-1000", counter: .init(counter: 2), setOfInts: [3, 4, 5, 6, 7], dictionaryOfInts: ["a":2])
 
         let newPersonExpected = NewPerson(name: "Krzysztof", age: 29, address: expectedAddress, secondAddress: expectedAddress, pet: nil)
         let newPersonActual = NewPerson(name: "Krzysztof", age: 29, address: actualAddress, secondAddress: actualAddress, pet: nil)
 
         let results = diff(newPersonExpected, newPersonActual)
+        dumpDiff(newPersonExpected, newPersonActual)
 
         XCTAssertEqual(results.first!, "" )
         print("@@@@@@@@@@@@")
@@ -194,6 +197,7 @@ class DifferenceTests: XCTestCase {
 
         let results = diff(newPersonExpected, newPersonActual)
 
+        dumpDiff(newPersonExpected, newPersonActual)
         XCTAssertEqual(results.first!, "" )
         print(results.joined(separator: "\n"))
 

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -75,7 +75,6 @@ private enum State {
 }
 
 class DifferenceTests: XCTestCase {
-
     func testCanFindRootPrimitiveDifference() {
         let results = diff(2, 3)
 
@@ -237,4 +236,26 @@ class DifferenceTests: XCTestCase {
         XCTAssertEqual(results.count, 1)
         XCTAssertEqual(results.first, "favoriteFoods:\n|\tsome:\n|\t|\tMissing: Pizza\n|\t|\tMissing: Sushi\n")
     }
+}
+
+extension DifferenceTests {
+    static var allTests = [
+        ("testCanFindRootPrimitiveDifference", testCanFindRootPrimitiveDifference),
+        ("testCanFindPrimitiveDifference", testCanFindPrimitiveDifference),
+        ("testCanFindMultipleDifference", testCanFindMultipleDifference),
+        ("testCanFindComplexDifference", testCanFindComplexDifference),
+        ("testCanGiveDescriptionForOptionalOnLeftSide", testCanGiveDescriptionForOptionalOnLeftSide),
+        ("testCanGiveDescriptionForOptionalOnRightSide", testCanGiveDescriptionForOptionalOnRightSide),
+        ("test_canFindCollectionCountDifference", test_canFindCollectionCountDifference),
+        ("test_canFindCollectionCountDifference_complex", test_canFindCollectionCountDifference_complex),
+        ("test_labelsArrayElementsInDiff", test_labelsArrayElementsInDiff),
+        ("test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical", test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical),
+        ("test_canFindEnumCaseDifferenceWhenLessArguments", test_canFindEnumCaseDifferenceWhenLessArguments),
+        ("test_canFindDictionaryCountDifference", test_canFindDictionaryCountDifference),
+        ("test_canFindOptionalDifferenceBetweenSomeAndNone", test_canFindOptionalDifferenceBetweenSomeAndNone),
+        ("test_canFindDictionaryDifference", test_canFindDictionaryDifference),
+        ("test_canFindSetCountDifference", test_canFindSetCountDifference),
+        ("test_canFindOptionalSetDifferenceBetweenSomeAndNone", test_canFindOptionalSetDifferenceBetweenSomeAndNone),
+        ("test_canFindSetDifference", test_canFindSetDifference)
+    ]
 }

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -71,18 +71,12 @@ private enum State {
     case loaded([Int], String)
     case anotherLoaded([Int], String)
     case loadedWithDiffArguments(Int)
-}
-
-private func dumpDiffSurround<T>(_ lhs: T, _ rhs: T) {
-    print("====START DIFF====")
-    dumpDiff(lhs, rhs)
-    print("=====END DIFF=====")
+    case loadedWithNoArguments
 }
 
 class DifferenceTests: XCTestCase {
 
     func testCanFindRootPrimitiveDifference() {
-        dumpDiffSurround(2, 3)
         let results = diff(2, 3)
 
         XCTAssertEqual(results.count, 1)
@@ -93,8 +87,6 @@ class DifferenceTests: XCTestCase {
 
     func testCanFindPrimitiveDifference() {
         let stub = Person(age: 30)
-
-//        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
@@ -104,8 +96,6 @@ class DifferenceTests: XCTestCase {
 
     func testCanFindMultipleDifference() {
         let stub = Person(name: "Adam", age: 30)
-
-        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 2)
@@ -115,8 +105,6 @@ class DifferenceTests: XCTestCase {
 
     func testCanFindComplexDifference() {
         let stub = Person(address: Person.Address(street: "2nd Street", counter: .init(counter: 1)))
-
-        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
@@ -127,26 +115,22 @@ class DifferenceTests: XCTestCase {
     func testCanGiveDescriptionForOptionalOnLeftSide() {
         let truth = Person(pet: nil)
         let stub = Person()
-
-//        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
+
         XCTAssertEqual(results.count, 1)
     }
 
     func testCanGiveDescriptionForOptionalOnRightSide() {
         let truth = Person()
         let stub = Person(pet: nil)
-
-//        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
+
         XCTAssertEqual(results.count, 1)
     }
 
     // MARK: Collections
 
     func test_canFindCollectionCountDifference() {
-//        dumpDiffSurround([1], [1, 3])
-
         let results = diff([1], [1, 3])
 
         XCTAssertEqual(results.count, 1)
@@ -156,8 +140,6 @@ class DifferenceTests: XCTestCase {
     func test_canFindCollectionCountDifference_complex() {
         let truth = State.loaded([1, 2], "truthString")
         let stub = State.loaded([], "stubString")
-        dumpDiffSurround(truth, stub)
-
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
@@ -167,8 +149,6 @@ class DifferenceTests: XCTestCase {
     func test_labelsArrayElementsInDiff() {
         let truth = [Person(), Person(name: "John")]
         let stub = [Person(name: "John"), Person()]
-
-        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 2)
@@ -181,8 +161,6 @@ class DifferenceTests: XCTestCase {
     func test_canFindEnumCaseDifferenceWhenAssociatedValuesAreIdentical() {
         let truth = State.loaded([0], "CommonString")
         let stub = State.anotherLoaded([0], "CommonString")
-
-        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
@@ -192,8 +170,6 @@ class DifferenceTests: XCTestCase {
     func test_canFindEnumCaseDifferenceWhenLessArguments() {
         let truth = State.loaded([0], "CommonString")
         let stub = State.loadedWithDiffArguments(1)
-
-//        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
@@ -205,8 +181,6 @@ class DifferenceTests: XCTestCase {
     func test_canFindDictionaryCountDifference() {
         let truth = Person(petAges: ["Henny": 4])
         let stub = Person(petAges: [:])
-
-        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
@@ -216,8 +190,6 @@ class DifferenceTests: XCTestCase {
     func test_canFindOptionalDifferenceBetweenSomeAndNone() {
         let truth = Person(petAges: ["Henny": 4, "Jethro": 6])
         let stub = Person(petAges: nil)
-
-//        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
@@ -233,8 +205,6 @@ class DifferenceTests: XCTestCase {
     func test_canFindDictionaryDifference() {
         let truth = Person(petAges: ["Henny": 4, "Jethro": 6])
         let stub = Person(petAges: ["Henny": 1, "Jethro": 2])
-
-//        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
@@ -251,8 +221,6 @@ class DifferenceTests: XCTestCase {
     func test_canFindSetCountDifference() {
         let truth = Person(favoriteFoods: [])
         let stub = Person(favoriteFoods: ["Oysters"])
-
-//        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
@@ -262,8 +230,6 @@ class DifferenceTests: XCTestCase {
     func test_canFindOptionalSetDifferenceBetweenSomeAndNone() {
         let truth = Person(favoriteFoods: ["Oysters"])
         let stub = Person(favoriteFoods: nil)
-
-//        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
@@ -273,8 +239,6 @@ class DifferenceTests: XCTestCase {
     func test_canFindSetDifference() {
         let truth = Person(favoriteFoods: ["Sushi", "Pizza"])
         let stub = Person(favoriteFoods: ["Oysters", "Crab"])
-
-        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -86,7 +86,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(2, 3)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "R7Received: 3\nExpected: 2\n")
+        XCTAssertEqual(results.first, "Received: 3\nExpected: 2\n")
     }
 
     fileprivate let truth = Person()
@@ -98,7 +98,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "R9Child age:\nR6|\tReceived: 30\n|\tExpected: 29\n")
+        XCTAssertEqual(results.first, "Child age:\n|\tReceived: 30\n|\tExpected: 29\n")
 
     }
 
@@ -109,18 +109,18 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 2)
-        XCTAssertEqual(results.first, "R9Child name:\nR6|\tReceived: Adam\n|\tExpected: Krzysztof\n")
-        XCTAssertEqual(results.last, "R9Child age:\nR6|\tReceived: 30\n|\tExpected: 29\n")
+        XCTAssertEqual(results.first, "Child name:\n|\tReceived: Adam\n|\tExpected: Krzysztof\n")
+        XCTAssertEqual(results.last, "Child age:\n|\tReceived: 30\n|\tExpected: 29\n")
     }
 
     func testCanFindComplexDifference() {
         let stub = Person(address: Person.Address(street: "2nd Street", counter: .init(counter: 1)))
 
-//        dumpDiffSurround(truth, stub)
+        dumpDiffSurround(truth, stub)
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "R8Child address:\nR9|\tChild street:\nR6|\t|\tReceived: 2nd Street\n|\t|\tExpected: Times Square\nR8|\tChild counter:\nR9|\t|\tChild counter:\nR6|\t|\t|\tReceived: 1\n|\t|\t|\tExpected: 2\n")
+        XCTAssertEqual(results.first, "Child address:\n|\tChild street:\n|\t|\tReceived: 2nd Street\n|\t|\tExpected: Times Square\n|\tChild counter:\n|\t|\tChild counter:\n|\t|\t|\tReceived: 1\n|\t|\t|\tExpected: 2\n")
 
     }
 
@@ -150,18 +150,30 @@ class DifferenceTests: XCTestCase {
         let results = diff([1], [1, 3])
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "R10Different count:\nR1|\tReceived: (2) [1, 3]\n|\tExpected: (1) [1]\n")
+        XCTAssertEqual(results.first, "Different count:\n|\tReceived: (2) [1, 3]\n|\tExpected: (1) [1]\n")
     }
 
     func test_canFindCollectionCountDifference_complex() {
         let truth = State.loaded([1, 2], "truth")
         let stub = State.loaded([], "stub")
-//        dumpDiffSurround(truth, stub)
+        dumpDiffSurround(truth, stub)
 
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "R8Enum loaded:\nR8|\tChild .0:\nR10|\t|\tDifferent count:\nR1|\t|\t|\tReceived: (0) []\n|\t|\t|\tExpected: (2) [1, 2]\nR9|\tChild .1:\nR6|\t|\tReceived: stub\n|\t|\tExpected: truth\n")
+        XCTAssertEqual(results.first, "Enum loaded:\n|\tChild .0:\n|\t|\tDifferent count:\n|\t|\t|\tReceived: (0) []\n|\t|\t|\tExpected: (2) [1, 2]\n|\tChild .1:\n|\t|\tReceived: stub\n|\t|\tExpected: truth\n")
+    }
+
+    func test_labelsArrayElementsInDiff() {
+        let truth = [Person(), Person(name: "John")]
+        let stub = [Person(name: "John"), Person()]
+
+        dumpDiffSurround(truth, stub)
+        let results = diff(truth, stub)
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results.first, "Collection[0]:\n|\tChild name:\n|\t|\tReceived: John\n|\t|\tExpected: Krzysztof\n")
+        XCTAssertEqual(results.last, "Collection[1]:\n|\tChild name:\n|\t|\tReceived: Krzysztof\n|\t|\tExpected: John\n")
     }
 
     // MARK: Enums
@@ -174,7 +186,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "R5Received: anotherLoaded\nExpected: loaded\n")
+        XCTAssertEqual(results.first, "Received: anotherLoaded\nExpected: loaded\n")
     }
 
     func test_canFindEnumCaseDifferenceWhenLessArguments() {
@@ -185,7 +197,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "R5Received: loadedWithDiffArguments\nExpected: loaded\n")
+        XCTAssertEqual(results.first, "Received: loadedWithDiffArguments\nExpected: loaded\n")
     }
 
     // MARK: Dictionaries
@@ -198,7 +210,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "R8Child petAges:\nR8|\tChild some:\nR10|\t|\tDifferent count:\nR1|\t|\t|\tReceived: (0) [:]\n|\t|\t|\tExpected: (1) [\"Henny\": 4]\n")
+        XCTAssertEqual(results.first, "Child petAges:\n|\tChild some:\n|\t|\tDifferent count:\n|\t|\t|\tReceived: (0) [:]\n|\t|\t|\tExpected: (1) [\"Henny\": 4]\n")
     }
 
     func test_canFindOptionalDifferenceBetweenSomeAndNone() {
@@ -209,7 +221,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        let header = "R8Child petAges:\nR7|\tReceived: nil\n|\tExpected: Optional(["
+        let header = "Child petAges:\n|\tReceived: nil\n|\tExpected: Optional(["
         let hennyDiff = "\"Henny\": 4"
         let jethroDiff = "\"Jethro\": 6"
         let endingDiff = "])\n"
@@ -226,9 +238,9 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        let header = "R8Child petAges:\nR8|\tChild some:\n"
-        let jethroDiff = "R2|\t|\tChild key Jethro:\nR9|\t|\t|\tChild some:\nR6|\t|\t|\t|\tReceived: 2\n|\t|\t|\t|\tExpected: 6\n"
-        let hennyDiff = "R2|\t|\tChild key Henny:\nR9|\t|\t|\tChild some:\nR6|\t|\t|\t|\tReceived: 1\n|\t|\t|\t|\tExpected: 4\n"
+        let header = "Child petAges:\n|\tChild some:\n"
+        let jethroDiff = "|\t|\tChild key Jethro:\n|\t|\t|\tChild some:\n|\t|\t|\t|\tReceived: 2\n|\t|\t|\t|\tExpected: 6\n"
+        let hennyDiff = "|\t|\tChild key Henny:\n|\t|\t|\tChild some:\n|\t|\t|\t|\tReceived: 1\n|\t|\t|\t|\tExpected: 4\n"
         let firstPermutation = header + jethroDiff + hennyDiff
         let secondPermutation = header + hennyDiff + jethroDiff
         XCTAssertTrue(assertEither(expected: (firstPermutation, secondPermutation), received: results.first))
@@ -244,7 +256,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "R8Child favoriteFoods:\nR8|\tChild some:\nR10|\t|\tDifferent count:\nR1|\t|\t|\tReceived: (1) [\"Oysters\"]\n|\t|\t|\tExpected: (0) []\n")
+        XCTAssertEqual(results.first, "Child favoriteFoods:\n|\tChild some:\n|\t|\tDifferent count:\n|\t|\t|\tReceived: (1) [\"Oysters\"]\n|\t|\t|\tExpected: (0) []\n")
     }
 
     func test_canFindOptionalSetDifferenceBetweenSomeAndNone() {
@@ -255,7 +267,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        XCTAssertEqual(results.first, "R8Child favoriteFoods:\nR7|\tReceived: nil\n|\tExpected: Optional(Set([\"Oysters\"]))\n")
+        XCTAssertEqual(results.first, "Child favoriteFoods:\n|\tReceived: nil\n|\tExpected: Optional(Set([\"Oysters\"]))\n")
     }
 
     func test_canFindSetDifference() {
@@ -266,9 +278,9 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        let header = "R8Child favoriteFoods:\nR8|\tChild some:\n"
-        let sushiDiff = "R3|\t|\tMissing: Sushi\n"
-        let pizzaDiff = "R3|\t|\tMissing: Pizza\n"
+        let header = "Child favoriteFoods:\n|\tChild some:\n"
+        let sushiDiff = "|\t|\tMissing: Sushi\n"
+        let pizzaDiff = "|\t|\tMissing: Pizza\n"
         let firstPermutation = header + sushiDiff + pizzaDiff
         let secondPermutation = header + pizzaDiff + sushiDiff
         XCTAssertTrue(assertEither(expected: (firstPermutation, secondPermutation), received: results.first))

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -201,11 +201,7 @@ class DifferenceTests: XCTestCase {
         let results = diff(truth, stub)
 
         XCTAssertEqual(results.count, 1)
-        let header = "petAges:\n|\tsome:\n"
-        let jethroDiff = "|\t|\tKey Jethro:\n|\t|\t|\tsome:\n|\t|\t|\t|\tReceived: 2\n|\t|\t|\t|\tExpected: 6\n"
-        let hennyDiff = "|\t|\tKey Henny:\n|\t|\t|\tsome:\n|\t|\t|\t|\tReceived: 1\n|\t|\t|\t|\tExpected: 4\n"
-        let secondPermutation = header + hennyDiff + jethroDiff
-        XCTAssertEqual(results.first, secondPermutation)
+        XCTAssertEqual(results.first, "petAges:\n|\tsome:\n|\t|\tKey Henny:\n|\t|\t|\tsome:\n|\t|\t|\t|\tReceived: 1\n|\t|\t|\t|\tExpected: 4\n|\t|\tKey Jethro:\n|\t|\t|\tsome:\n|\t|\t|\t|\tReceived: 2\n|\t|\t|\t|\tExpected: 6\n")
     }
 
     // MARK: Sets


### PR DESCRIPTION
This PR attempts to achieve a few things:

* Refactored how diffs are produced. The library now uses an internal type `Line` to produces an array during the diff process. A `Line` may have children associated with it represented diffs in substructures of the values being compared. For example, when diffing an instance of `Person`, we may have the line `address` which has two children `street` and `postcode`, indicating that there are two differences associated with `address`. This moves the responsibility of indentation to a higher level and will make it easier to add other types of indentation (one I'd like to do is KeyPaths style: `person.address: <difference1>\n<difference2>` to aid with very deep structures)
In addition, `Line` can specify if it can be re-ordered. Lines such as `Different count` or `Expected/Received` cannot be re-ordered, but anything dynamic (like the name of a property) can be ordered for a consistent experience + easier testing.

* Added specific entry diffing for `Dictionary`. Currently, the dictionary handling does not match with the correct entry. For example:
```
let truth = ["Henny": 4, "Jethro": 6]
let stub = ["Henny": 1, "Jethro": 2]
diff(truth, stub)
// Sometimes produces:
// received: "(key: "Henny", value: 1)" expected: "(key: "Jethro", value: 6)"
// received: "(key: "Jethro", value: 2)" expected: "(key: "Henny", value: 4)"
```
This is due to the dictionary being compared as a list of tuples. To fix this, I cast the two values being compared to `Dictionary<AnyHashable, Any>`, then diff each key to its responding bucket in the other dictionary. This outputs in the form `Key <Key>: <difference>`.

* Added support for `Set` diffing. Elements in a set are always `Hashable`, so we can cast to `Set<Hashable>` to be able to better compare sets. When the sets are cast, we can check which elements are missing from the expected `Set`. Here's an example:
```
let truth = Person(favoriteFoods: ["Sushi", "Pizza"])
let stub = Person(favoriteFoods: ["Oysters", "Crab"])
let results = diff(truth, stub)
// Produces:
//   Missing: Pizza
//   Missing: Sushi
``` 

* Improved enum handling. If there are two enum cases being compared that are different, then we don't print the enums in their entirety. Knowing that they're different cases is usually all you need to know.

* Added labelling for enums to indicate that the child beneath is part of an enum, as sometimes it can be hard to discern property types inside the diff.

* Added customisation of indentation type. Default is `pipe`, which adds pipes to easily track which properties are at the same level of depth:
```
    /// `pipe` example:
    ///     address:
    ///     |    street:
    ///     |    |    Received: 2nd Street
    ///     |    |    Expected: Times Square
    ///     |    counter:
    ///     |    |    counter:
    ///     |    |    |    Received: 1
    ///     |    |    |    Expected: 2
    /// `tab` example:
    ///     address:
    ///         street:
    ///             Received: 2nd Street
    ///             Expected: Times Square
    ///         counter:
    ///             counter:
    ///                 Received: 1
    ///                 Expected: 2
```
I'd like to expand this at a later point to include KeyPath style as mentioned above.

* Added lots of tests for cases I could think of.
