### PR TITLE
Added skipPrintingOnDiffCount, refactored tests

### DIFF
--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -10,88 +10,182 @@ import Foundation
 
 private typealias IndentationType = Difference.IndentationType
 
-fileprivate func diffLines<T>(_ expected: T, _ received: T, level: Int = 0) -> [Line] {
-    let expectedMirror = Mirror(reflecting: expected)
-    let receivedMirror = Mirror(reflecting: received)
+private struct Differ {
+    private let indentationType: IndentationType
+    private let skipPrintingOnDiffCount: Bool
 
-    guard expectedMirror.children.count != 0, receivedMirror.children.count != 0 else {
-        if String(dumping: received) != String(dumping: expected) {
-            return handleChildless(expected, expectedMirror, received, receivedMirror, level)
-        }
-        return []
+    init(
+        indentationType: IndentationType,
+        skipPrintingOnDiffCount: Bool
+    ) {
+        self.indentationType = indentationType
+        self.skipPrintingOnDiffCount = skipPrintingOnDiffCount
     }
 
-    let hasDiffNumOfChildren = expectedMirror.children.count != receivedMirror.children.count
-    switch (expectedMirror.displayStyle, receivedMirror.displayStyle) {
-    case (.collection?, .collection?) where hasDiffNumOfChildren,
-         (.dictionary?, .dictionary?) where hasDiffNumOfChildren,
-         (.set?, .set?) where hasDiffNumOfChildren,
-         (.enum?, .enum?) where hasDiffNumOfChildren:
-        return [generateDifferentCountBlock(expected, expectedMirror, received, receivedMirror, level)]
-    case (.dictionary?, .dictionary?):
-        if let expectedDict = expected as? Dictionary<AnyHashable, Any>,
-            let receivedDict = received as? Dictionary<AnyHashable, Any> {
-            var resultLines: [Line] = []
-            expectedDict.keys.forEach { key in
-                let results = diffLines(expectedDict[key], receivedDict[key], level: level + 1)
-                if !results.isEmpty {
-                    resultLines.append(Line(contents: "Key \(key.description):", indentationLevel: level, canBeOrdered: true, children: results))
-                }
-            }
-            return resultLines
-        }
-    case (.set?, .set?):
-        if let expectedSet = expected as? Set<AnyHashable>,
-            let receivedSet = received as? Set<AnyHashable> {
-            return expectedSet.subtracting(receivedSet)
-                .map { unique in
-                    Line(contents: "Missing: \(unique.description)", indentationLevel: level, canBeOrdered: true)
-                }
-        }
-    // Handles different enum cases that have children to prevent printing entire object
-    case (.enum?, .enum?) where expectedMirror.children.first?.label != receivedMirror.children.first?.label:
-        let expectedPrintable = enumLabelFromFirstChild(expectedMirror) ?? "UNKNOWN"
-        let receivedPrintable = enumLabelFromFirstChild(receivedMirror) ?? "UNKNOWN"
-        return generateExpectedReceiveLines(expectedPrintable, receivedPrintable, level)
-    default:
-        break
+    func diff<T>(_ expected: T, _ received: T) -> [String] {
+        let lines = diffLines(expected, received, level: 0)
+        return buildLineContents(lines: lines)
     }
 
-    var resultLines = [Line]()
-    let zipped = zip(expectedMirror.children, receivedMirror.children)
-    zipped.enumerated().forEach { (index, zippedValues) in
-        let lhs = zippedValues.0
-        let rhs = zippedValues.1
-        let leftDump = String(dumping: lhs.value)
-        if leftDump != String(dumping: rhs.value) {
-            // Remove embedding of `some` for optional types, as it offers no value
-            guard expectedMirror.displayStyle != .optional else {
-                let results = diffLines(lhs.value, rhs.value, level: level)
-                resultLines.append(contentsOf: results)
-                return
+    fileprivate func diffLines<T>(_ expected: T, _ received: T, level: Int = 0) -> [Line] {
+        let expectedMirror = Mirror(reflecting: expected)
+        let receivedMirror = Mirror(reflecting: received)
+
+        guard expectedMirror.children.count != 0, receivedMirror.children.count != 0 else {
+            if String(dumping: received) != String(dumping: expected) {
+                return handleChildless(expected, expectedMirror, received, receivedMirror, level)
             }
-            if Mirror(reflecting: lhs.value).displayStyle != nil {
-                let results = diffLines(lhs.value, rhs.value, level: level + 1)
-                if !results.isEmpty {
-                    let line = Line(contents: "\(expectedMirror.displayStyleDescriptor(index: index))\(lhs.label ?? ""):",
-                        indentationLevel: level,
-                        canBeOrdered: true,
-                        children: results
+            return []
+        }
+
+        let hasDiffNumOfChildren = expectedMirror.children.count != receivedMirror.children.count
+        switch (expectedMirror.displayStyle, receivedMirror.displayStyle) {
+        case (.collection?, .collection?) where hasDiffNumOfChildren,
+             (.dictionary?, .dictionary?) where hasDiffNumOfChildren,
+             (.set?, .set?) where hasDiffNumOfChildren,
+             (.enum?, .enum?) where hasDiffNumOfChildren:
+            return [generateDifferentCountBlock(expected, expectedMirror, received, receivedMirror, level)]
+        case (.dictionary?, .dictionary?):
+            if let expectedDict = expected as? Dictionary<AnyHashable, Any>,
+                let receivedDict = received as? Dictionary<AnyHashable, Any> {
+                var resultLines: [Line] = []
+                expectedDict.keys.forEach { key in
+                    let results = diffLines(expectedDict[key], receivedDict[key], level: level + 1)
+                    if !results.isEmpty {
+                        resultLines.append(Line(contents: "Key \(key.description):", indentationLevel: level, canBeOrdered: true, children: results))
+                    }
+                }
+                return resultLines
+            }
+        case (.set?, .set?):
+            if let expectedSet = expected as? Set<AnyHashable>,
+                let receivedSet = received as? Set<AnyHashable> {
+                return expectedSet.subtracting(receivedSet)
+                    .map { unique in
+                        Line(contents: "Missing: \(unique.description)", indentationLevel: level, canBeOrdered: true)
+                    }
+            }
+        // Handles different enum cases that have children to prevent printing entire object
+        case (.enum?, .enum?) where expectedMirror.children.first?.label != receivedMirror.children.first?.label:
+            let expectedPrintable = enumLabelFromFirstChild(expectedMirror) ?? "UNKNOWN"
+            let receivedPrintable = enumLabelFromFirstChild(receivedMirror) ?? "UNKNOWN"
+            return generateExpectedReceiveLines(expectedPrintable, receivedPrintable, level)
+        default:
+            break
+        }
+
+        var resultLines = [Line]()
+        let zipped = zip(expectedMirror.children, receivedMirror.children)
+        zipped.enumerated().forEach { (index, zippedValues) in
+            let lhs = zippedValues.0
+            let rhs = zippedValues.1
+            let leftDump = String(dumping: lhs.value)
+            if leftDump != String(dumping: rhs.value) {
+                // Remove embedding of `some` for optional types, as it offers no value
+                guard expectedMirror.displayStyle != .optional else {
+                    let results = diffLines(lhs.value, rhs.value, level: level)
+                    resultLines.append(contentsOf: results)
+                    return
+                }
+                if Mirror(reflecting: lhs.value).displayStyle != nil {
+                    let results = diffLines(lhs.value, rhs.value, level: level + 1)
+                    if !results.isEmpty {
+                        let line = Line(contents: "\(expectedMirror.displayStyleDescriptor(index: index))\(lhs.label ?? ""):",
+                            indentationLevel: level,
+                            canBeOrdered: true,
+                            children: results
+                        )
+                        resultLines.append(line)
+                    }
+                } else {
+                    let childName = "\(expectedMirror.displayStyleDescriptor(index: index))\(lhs.label ?? ""):"
+                    let children = generateExpectedReceiveLines(
+                        String(describing: lhs.value),
+                        String(describing: rhs.value),
+                        level + 1
                     )
-                    resultLines.append(line)
+                    resultLines.append(Line(contents: childName, indentationLevel: level, canBeOrdered: true, children: children))
                 }
-            } else {
-                let childName = "\(expectedMirror.displayStyleDescriptor(index: index))\(lhs.label ?? ""):"
-                let children = generateExpectedReceiveLines(
-                    String(describing: lhs.value),
-                    String(describing: rhs.value),
-                    level + 1
-                )
-                resultLines.append(Line(contents: childName, indentationLevel: level, canBeOrdered: true, children: children))
             }
         }
+        return resultLines
     }
-    return resultLines
+
+
+    fileprivate func handleChildless<T>(
+        _ expected: T,
+        _ expectedMirror: Mirror,
+        _ received: T,
+        _ receivedMirror: Mirror,
+        _ indentationLevel: Int
+    ) -> [Line] {
+        // Empty collections are "childless", so we may need to generate a different count block instead of treating as a
+        // childless enum.
+        guard !expectedMirror.canBeEmpty else {
+            return [generateDifferentCountBlock(expected, expectedMirror, received, receivedMirror, indentationLevel)]
+        }
+
+        let receivedPrintable: String
+        let expectedPrintable: String
+        // Received mirror has a different number of arguments to expected
+        if receivedMirror.children.count == 0, expectedMirror.children.count != 0 {
+            // Print whole description of received, as it's only a label if childless
+            receivedPrintable = String(dumping: received)
+            // Get the label from the expected, to prevent printing long list of arguments
+            expectedPrintable = enumLabelFromFirstChild(expectedMirror) ?? String(describing: expected)
+        } else if expectedMirror.children.count == 0, receivedMirror.children.count != 0 {
+            receivedPrintable = enumLabelFromFirstChild(receivedMirror) ?? String(describing: received)
+            expectedPrintable = String(dumping: expected)
+        } else {
+            receivedPrintable = String(describing: received)
+            expectedPrintable = String(describing: expected)
+        }
+        return generateExpectedReceiveLines(expectedPrintable, receivedPrintable, indentationLevel)
+    }
+
+    private func generateDifferentCountBlock<T>(
+        _ expected: T,
+        _ expectedMirror: Mirror,
+        _ received: T,
+        _ receivedMirror: Mirror,
+        _ indentationLevel: Int
+    ) -> Line {
+        var expectedPrintable = "(\(expectedMirror.children.count))"
+        var receivedPrintable = "(\(receivedMirror.children.count))"
+        if !skipPrintingOnDiffCount {
+            expectedPrintable.append(" \(expected)")
+            receivedPrintable.append(" \(received)")
+        }
+        return Line(
+            contents: "Different count:",
+            indentationLevel: indentationLevel,
+            canBeOrdered: false,
+            children: generateExpectedReceiveLines(expectedPrintable, receivedPrintable, indentationLevel + 1)
+        )
+    }
+
+    private func generateExpectedReceiveLines(
+        _ expected: String,
+        _ received: String,
+        _ indentationLevel: Int
+    ) -> [Line] {
+        return [
+            Line(contents: "Received: \(received)", indentationLevel: indentationLevel, canBeOrdered: false),
+            Line(contents: "Expected: \(expected)", indentationLevel: indentationLevel, canBeOrdered: false)
+        ]
+    }
+
+    private func buildLineContents(lines: [Line]) -> [String] {
+        let linesContents = lines.map { line in line.generateContents(indentationType: indentationType) }
+        // In the case of this being a top level failure (e.g. both mirrors have no children, like comparing two
+        // primitives `diff(2,3)`, we only want to produce one failure to have proper spacing.
+        let isOnlyTopLevelFailure = lines.map { $0.hasChildren }.filter { $0 }.isEmpty
+        if isOnlyTopLevelFailure {
+            return [linesContents.joined()]
+        } else {
+            return linesContents
+        }
+    }
 }
 
 public enum Difference {
@@ -114,7 +208,7 @@ public enum Difference {
     ///             counter:
     ///                 Received: 1
     ///                 Expected: 2
-    public enum IndentationType: String {
+    public enum IndentationType: String, CaseIterable {
         case pipe = "|\t"
         case tab = "\t"
     }
@@ -155,65 +249,6 @@ private struct Line {
     private func indentation(level: Int, indentationType: IndentationType) -> String {
         (0..<level).reduce("") { acc, _ in acc + "\(indentationType.rawValue)" }
     }
-}
-
-fileprivate func handleChildless<T>(
-    _ expected: T,
-    _ expectedMirror: Mirror,
-    _ received: T,
-    _ receivedMirror: Mirror,
-    _ indentationLevel: Int
-) -> [Line] {
-    // Empty collections are "childless", so we may need to generate a different count block instead of treating as a
-    // childless enum.
-    guard !expectedMirror.canBeEmpty else {
-        return [generateDifferentCountBlock(expected, expectedMirror, received, receivedMirror, indentationLevel)]
-    }
-
-    let receivedPrintable: String
-    let expectedPrintable: String
-    // Received mirror has a different number of arguments to expected
-    if receivedMirror.children.count == 0, expectedMirror.children.count != 0 {
-        // Print whole description of received, as it's only a label if childless
-        receivedPrintable = String(dumping: received)
-        // Get the label from the expected, to prevent printing long list of arguments
-        expectedPrintable = enumLabelFromFirstChild(expectedMirror) ?? String(describing: expected)
-    } else if expectedMirror.children.count == 0, receivedMirror.children.count != 0 {
-        receivedPrintable = enumLabelFromFirstChild(receivedMirror) ?? String(describing: received)
-        expectedPrintable = String(dumping: expected)
-    } else {
-        receivedPrintable = String(describing: received)
-        expectedPrintable = String(describing: expected)
-    }
-    return generateExpectedReceiveLines(expectedPrintable, receivedPrintable, indentationLevel)
-}
-
-private func generateDifferentCountBlock<T>(
-    _ expected: T,
-    _ expectedMirror: Mirror,
-    _ received: T,
-    _ receivedMirror: Mirror,
-    _ indentationLevel: Int
-) -> Line {
-    let expectedPrintable = "(\(expectedMirror.children.count)) \(expected)"
-    let receivedPrintable = "(\(receivedMirror.children.count)) \(received)"
-    return Line(
-        contents: "Different count:",
-        indentationLevel: indentationLevel,
-        canBeOrdered: false,
-        children: generateExpectedReceiveLines(expectedPrintable, receivedPrintable, indentationLevel + 1)
-    )
-}
-
-private func generateExpectedReceiveLines(
-    _ expected: String,
-    _ received: String,
-    _ indentationLevel: Int
-) -> [Line] {
-    return [
-        Line(contents: "Received: \(received)", indentationLevel: indentationLevel, canBeOrdered: false),
-        Line(contents: "Expected: \(expected)", indentationLevel: indentationLevel, canBeOrdered: false)
-    ]
 }
 
 fileprivate extension String {
@@ -267,22 +302,18 @@ fileprivate extension Mirror {
 /// - Parameters:
 ///   - expected: Expected value
 ///   - received: Received value
+///   - indentationType: Style of indentation to use
+///   - skipPrintingOnDiffCount: Skips the printing of the object when a collection has a different count
+///
 /// - Returns: List of differences
 public func diff<T>(
     _ expected: T,
     _ received: T,
-    indentationType: Difference.IndentationType = .pipe
+    indentationType: Difference.IndentationType = .pipe,
+    skipPrintingOnDiffCount: Bool = false
 ) -> [String] {
-    let lines = diffLines(expected, received)
-    let linesContents = lines.map { line in line.generateContents(indentationType: indentationType) }
-    // In the case of this being a top level failure (e.g. both mirrors have no children, like comparing two
-    // primitives `diff(2,3)`, we only want to produce one failure to have proper spacing.
-    let isOnlyTopLevelFailure = lines.map { $0.hasChildren }.filter { $0 }.isEmpty
-    if isOnlyTopLevelFailure {
-        return [linesContents.joined()]
-    } else {
-        return linesContents
-    }
+    Differ(indentationType: indentationType, skipPrintingOnDiffCount: skipPrintingOnDiffCount)
+        .diff(expected, received)
 }
 
 /// Prints list of differences between 2 objects
@@ -290,17 +321,25 @@ public func diff<T>(
 /// - Parameters:
 ///   - expected: Expected value
 ///   - received: Received value
+///   - indentationType: Style of indentation to use
+///   - skipPrintingOnDiffCount: Skips the printing of the object when a collection has a different count
 public func dumpDiff<T: Equatable>(
     _ expected: T,
     _ received: T,
-    indentationType: Difference.IndentationType = .pipe
+    indentationType: Difference.IndentationType = .pipe,
+    skipPrintingOnDiffCount: Bool = false
 ) {
     // skip equal
     guard expected != received else {
         return
     }
 
-    diff(expected, received, indentationType: indentationType).forEach { print($0) }
+    diff(
+        expected,
+        received,
+        indentationType: indentationType,
+        skipPrintingOnDiffCount: skipPrintingOnDiffCount
+    ).forEach { print($0) }
 }
 
 
@@ -309,10 +348,18 @@ public func dumpDiff<T: Equatable>(
 /// - Parameters:
 ///   - expected: Expected value
 ///   - received: Received value
+///   - indentationType: Style of indentation to use
+///   - skipPrintingOnDiffCount: Skips the printing of the object when a collection has a different count
 public func dumpDiff<T>(
     _ expected: T,
     _ received: T,
-    indentationType: Difference.IndentationType = .pipe
+    indentationType: Difference.IndentationType = .pipe,
+    skipPrintingOnDiffCount: Bool = false
 ) {
-    diff(expected, received, indentationType: indentationType).forEach { print($0) }
+    diff(
+        expected,
+        received,
+        indentationType: indentationType,
+        skipPrintingOnDiffCount: skipPrintingOnDiffCount
+    ).forEach { print($0) }
 }


### PR DESCRIPTION
New parameter allows users to skip printing out complex diffs for objects, e.g.:

```
Found difference for:
Different count:
|   Received: (15) [Babylon.EditMembershipV2ViewModel.State(patient: BabylonCore.PatientDTO(id: BabylonCore.PatientID(rawValue: "48627"), uuid: nil, unwrappedInfo: BabylonCore.PatientPersonalInfo(firstName: "Brienne", lastName: "Skrilla", email: "brienne16skrilla@example.com", nationalPhoneNumber: nil, phoneCountryCode: nil, gender: nil, dateOfBirth: nil, ....)
|   expected: (16) [Babylon.EditMembershipV2ViewModel.State(patient: BabylonCore.PatientDTO(id: BabylonCore.PatientID(rawValue: "48627"), uuid: nil, unwrappedInfo: BabylonCore.PatientPersonalInfo(firstName: "Brienne", lastName: "Skrilla", email: "brienne16skrilla@example.com", nationalPhoneNumber: nil, phoneCountryCode: nil, gender: nil, dateOfBirth: nil, ....)
```

->

```
Different count:
|   Received: (15)
|   expected: (16)
```