### PR TITLE
Extra items for sets and dictionaries of the same size

### DIFF
--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -49,11 +49,28 @@ private struct Differ {
             if let expectedDict = expected as? Dictionary<AnyHashable, Any>,
                 let receivedDict = received as? Dictionary<AnyHashable, Any> {
                 var resultLines: [Line] = []
-                expectedDict.keys.forEach { key in
+                let missingKeys = Set(expectedDict.keys).subtracting(receivedDict.keys)
+                let extraKeys = Set(receivedDict.keys).subtracting(expectedDict.keys)
+                let commonKeys = Set(receivedDict.keys).intersection(expectedDict.keys)
+                commonKeys.forEach { key in
                     let results = diffLines(expectedDict[key], receivedDict[key], level: level + 1)
                     if !results.isEmpty {
                         resultLines.append(Line(contents: "Key \(key.description):", indentationLevel: level, canBeOrdered: true, children: results))
                     }
+                }
+                if (!missingKeys.isEmpty) {
+                    var missingKeyPairs: [Line] = []
+                    missingKeys.forEach { key in
+                        missingKeyPairs.append(Line(contents: "\(key.description): \(String(describing: expectedDict[key]))", indentationLevel: level + 1, canBeOrdered: true))
+                    }
+                    resultLines.append(Line(contents: "Missing key pairs:", indentationLevel: level, canBeOrdered: false, children: missingKeyPairs))
+                }
+                if (!extraKeys.isEmpty) {
+                    var extraKeyPairs: [Line] = []
+                    extraKeys.forEach { key in
+                        extraKeyPairs.append(Line(contents: "\(key.description): \(String(describing: receivedDict[key]))", indentationLevel: level + 1, canBeOrdered: true))
+                    }
+                    resultLines.append(Line(contents: "Extra key pairs:", indentationLevel: level, canBeOrdered: false, children: extraKeyPairs))
                 }
                 return resultLines
             }

--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -60,10 +60,15 @@ private struct Differ {
         case (.set?, .set?):
             if let expectedSet = expected as? Set<AnyHashable>,
                 let receivedSet = received as? Set<AnyHashable> {
-                return expectedSet.subtracting(receivedSet)
+                let missing = expectedSet.subtracting(receivedSet)
                     .map { unique in
                         Line(contents: "Missing: \(unique.description)", indentationLevel: level, canBeOrdered: true)
                     }
+                let extras = receivedSet.subtracting(expectedSet)
+                    .map { unique in
+                        Line(contents: "Extra: \(unique.description)", indentationLevel: level, canBeOrdered: true)
+                    }
+                return missing + extras
             }
         // Handles different enum cases that have children to prevent printing entire object
         case (.enum?, .enum?) where expectedMirror.children.first?.label != receivedMirror.children.first?.label:

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -233,6 +233,14 @@ class DifferenceTests: XCTestCase {
         )
     }
 
+    func test_canFindDictionaryKeyDifference() {
+        runTest(
+            expected: Person(petAges: ["Haddie": 4, "Jethro": 6]),
+            received: Person(petAges: ["Henny": 1, "Jethro": 2]),
+            expectedResults: ["petAges:\n|\tKey Jethro:\n|\t|\tReceived: 2\n|\t|\tExpected: 6\n|\tMissing key pairs:\n|\t|\tHaddie: Optional(4)\n|\tExtra key pairs:\n|\t|\tHenny: Optional(1)\n"]
+        )
+    }
+
     // MARK: Sets
 
     func test_canFindSetCountDifference() {
@@ -276,6 +284,7 @@ extension DifferenceTests {
         ("test_canFindDictionaryCountDifference", test_canFindDictionaryCountDifference),
         ("test_canFindOptionalDifferenceBetweenSomeAndNone", test_canFindOptionalDifferenceBetweenSomeAndNone),
         ("test_canFindDictionaryDifference", test_canFindDictionaryDifference),
+        ("test_canFindDictionaryKeyDifference", test_canFindDictionaryKeyDifference),
         ("test_canFindSetCountDifference", test_canFindSetCountDifference),
         ("test_canFindOptionalSetDifferenceBetweenSomeAndNone", test_canFindOptionalSetDifferenceBetweenSomeAndNone),
         ("test_canFindSetDifference", test_canFindSetDifference)

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -255,7 +255,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: Person(favoriteFoods: ["Sushi", "Pizza"]),
             received: Person(favoriteFoods: ["Oysters", "Crab"]),
-            expectedResults: ["favoriteFoods:\n|\tMissing: Pizza\n|\tMissing: Sushi\n"]
+            expectedResults: ["favoriteFoods:\n|\tExtra: Crab\n|\tExtra: Oysters\n|\tMissing: Pizza\n|\tMissing: Sushi\n"]
         )
     }
 }


### PR DESCRIPTION
When comparing collections with the same count, it's helpful to know the extra items along with the missing ones. Otherwise it requires 2 iterations to map out all the differences.