### PR TITLE
Update quick example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ public func equalDiff<T: Equatable>(_ expectedValue: T?) -> Predicate<T> {
         if receivedValue == nil {
             var message = ExpectationMessage.fail("")
             if let expectedValue = expectedValue {
-                message = ExpectationMessage.expectedCustomValueTo("equal <\(expectedValue)>", "nil")
+                message = ExpectationMessage.expectedCustomValueTo("equal <\(expectedValue)>", actual: "nil")
             }
             return PredicateResult(status: .fail, message: message)
         }

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ public func equalDiff<T: Equatable>(_ expectedValue: T?) -> Predicate<T> {
 }
 ```
 
+Write the following to see the difference between 2 instances:
+`expect(received).to(equalDiff(expected))`
+
 ## Integrate with The Composable Architecture
 
 If you are using The Composable Architecture `nameLabels` configuration to get a diff that's more appropiate for reducer instrumentation


### PR DESCRIPTION
I don't know how to use `equalDiff` when I saw the doc for the first time.
I think it's better to provide a usage example. 

`Quick` API has been changed, so we need to update the example code as well.