### PR TITLE
Objective-C enums support

### DIFF
--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -42,7 +42,6 @@ public struct DifferenceNameLabels {
     }
 }
 
-
 private struct Differ {
     private let indentationType: IndentationType
     private let skipPrintingOnDiffCount: Bool
@@ -70,6 +69,12 @@ private struct Differ {
         guard expectedMirror.children.count != 0, receivedMirror.children.count != 0 else {
             if String(dumping: received) != String(dumping: expected) {
                 return handleChildless(expected, expectedMirror, received, receivedMirror, level)
+            } else if expectedMirror.displayStyle == .enum {
+                let expectedValue = intValue(for: expected)
+                let receivedValue = intValue(for: received)
+                if expectedValue != receivedValue {
+                    return handleChildless(expectedValue, expectedMirror, receivedValue, receivedMirror, level)
+                }
             }
             return []
         }
@@ -164,6 +169,8 @@ private struct Differ {
                     )
                     resultLines.append(Line(contents: childName, indentationLevel: level, canBeOrdered: true, children: children))
                 }
+            } else {
+                resultLines.append(contentsOf: diffLines(lhs.value, rhs.value, level: level))
             }
         }
         return resultLines
@@ -242,6 +249,15 @@ private struct Differ {
             return [linesContents.joined()]
         } else {
             return linesContents
+        }
+    }
+
+    /// Creates int value from Objective-C enum.
+    private func intValue<T>(for object: T) -> Int {
+        withUnsafePointer(to: object) {
+            $0.withMemoryRebound(to: Int.self, capacity: 1) {
+                $0.pointee
+            }
         }
     }
 }

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -275,7 +275,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: Person(objcEnum: .overCurrentContext),
             received: Person(objcEnum: .overFullScreen),
-            expectedResults: ["Received: 5\nExpected: 6\n"]
+            expectedResults: ["objcEnum:\n|\tReceived: 5\n|\tExpected: 6\n"]
         )
     }
 

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -9,6 +9,7 @@
 import Foundation
 import XCTest
 import Difference
+import UIKit
 
 typealias IndentationType = Difference.IndentationType
 
@@ -19,6 +20,7 @@ fileprivate struct Person: Equatable {
     let pet: Pet?
     let petAges: [String: Int]?
     let favoriteFoods: Set<String>?
+    let objcEnum: UIModalPresentationStyle
 
     init(
         name: String = "Krzysztof",
@@ -26,7 +28,8 @@ fileprivate struct Person: Equatable {
         address: Address = .init(),
         pet: Pet? = .init(),
         petAges: [String: Int]? = nil,
-        favoriteFoods: Set<String>? = nil
+        favoriteFoods: Set<String>? = nil,
+        objcEnum: UIModalPresentationStyle = .formSheet
     ) {
         self.name = name
         self.age = age
@@ -34,6 +37,7 @@ fileprivate struct Person: Equatable {
         self.pet = pet
         self.petAges = petAges
         self.favoriteFoods = favoriteFoods
+        self.objcEnum = objcEnum
     }
 
     struct Address: Equatable {
@@ -265,6 +269,34 @@ class DifferenceTests: XCTestCase {
             received: Person(favoriteFoods: ["Oysters", "Crab"]),
             expectedResults: ["favoriteFoods:\n|\tExtra: Crab\n|\tExtra: Oysters\n|\tMissing: Pizza\n|\tMissing: Sushi\n"]
         )
+    }
+
+    func test_canFindObjCEnumDifferenceInStructure() {
+        runTest(
+            expected: Person(objcEnum: .overCurrentContext),
+            received: Person(objcEnum: .overFullScreen),
+            expectedResults: ["Received: 5\nExpected: 6\n"]
+        )
+    }
+
+    func test_canFindObjCEnumDifference() {
+        runTest(
+            expected: UIModalPresentationStyle.overCurrentContext,
+            received: UIModalPresentationStyle.overFullScreen,
+            expectedResults: ["Received: 5\nExpected: 6\n"]
+        )
+    }
+
+    func test_cannotFindDifferenceWithSameSwiftEnum() {
+        runTest(
+            expected: State.loadedWithNoArguments,
+            received: State.loadedWithNoArguments,
+            expectedResults: [""]
+        )
+    }
+
+    func test_cannotFindDifferenceWithSameObjects() {
+        runTest(expected: truth, received: truth, expectedResults: [""])
     }
 }
 


### PR DESCRIPTION
Implementation adds support for Objective-C enums.
Currently when comparing Objective-C enums using Difference it will succeed as Mirror has the same description.
When using XCTAssertEqual it will return:
`XCTAssertEqual failed: ("UIModalPresentationStyle") is not equal to ("UIModalPresentationStyle")`
This change will fail the test in case of Objective-C enums when using Difference, but it will also return Int value of the enum.

This PR closes #29.
