### PR TITLE
Handle ObjC enum cases when inside collections or deeply inside objects

### DIFF
--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -69,12 +69,20 @@ private struct Differ {
         guard expectedMirror.children.count != 0, receivedMirror.children.count != 0 else {
             if String(dumping: received) != String(dumping: expected) {
                 return handleChildless(expected, expectedMirror, received, receivedMirror, level)
-            } else if expectedMirror.unwrapped?.displayStyle == .enum {
+            } else if expectedMirror.displayStyle == .enum {
                 let expectedValue = intValue(for: expected)
                 let receivedValue = intValue(for: received)
                 if expectedValue != receivedValue {
                     return handleChildless(expectedValue, expectedMirror, receivedValue, receivedMirror, level)
                 }
+            }
+            return []
+        }
+
+        // Remove embedding of `some` for optional types, as it offers no value
+        guard expectedMirror.displayStyle != .optional else {
+            if let expectedUnwrapped = expectedMirror.firstChildenValue, let receivedUnwrapped = receivedMirror.firstChildenValue {
+                return diffLines(expectedUnwrapped, receivedUnwrapped, level: level)
             }
             return []
         }
@@ -143,42 +151,15 @@ private struct Differ {
             let lhs = zippedValues.0
             let rhs = zippedValues.1
             let childName = "\(expectedMirror.displayStyleDescriptor(index: index))\(lhs.label ?? ""):"
-            let leftDump = String(dumping: lhs.value)
-            if leftDump != String(dumping: rhs.value) {
-                // Remove embedding of `some` for optional types, as it offers no value
-                guard expectedMirror.displayStyle != .optional else {
-                    let results = diffLines(lhs.value, rhs.value, level: level)
-                    resultLines.append(contentsOf: results)
-                    return
-                }
-                if Mirror(reflecting: lhs.value).displayStyle != nil {
-                    let results = diffLines(lhs.value, rhs.value, level: level + 1)
-                    if !results.isEmpty {
-                        let line = Line(contents: childName,
-                            indentationLevel: level,
-                            canBeOrdered: true,
-                            children: results
-                        )
-                        resultLines.append(line)
-                    }
-                } else {
-                    let children = generateExpectedReceiveLines(
-                        String(describing: lhs.value),
-                        String(describing: rhs.value),
-                        level + 1
-                    )
-                    resultLines.append(Line(contents: childName, indentationLevel: level, canBeOrdered: true, children: children))
-                }
-            } else {
-                let results = diffLines(lhs.value, rhs.value, level: level + 1)
-                if !results.isEmpty {
-                    let line = Line(contents: childName,
-                        indentationLevel: level,
-                        canBeOrdered: true,
-                        children: results
-                    )
-                    resultLines.append(line)
-                }
+            let results = diffLines(lhs.value, rhs.value, level: level + 1)
+
+            if !results.isEmpty {
+                let line = Line(contents: childName,
+                    indentationLevel: level,
+                    canBeOrdered: true,
+                    children: results
+                )
+                resultLines.append(line)
             }
         }
         return resultLines
@@ -377,16 +358,8 @@ fileprivate extension Mirror {
         }
     }
 
-    var unwrapped: Mirror? {
-        guard displayStyle == .optional else {
-            return self
-        }
-        guard children.count != 0 else {
-            return nil
-        }
-
-        let (_, value) = children.first!
-        return Mirror(reflecting: value)
+    var firstChildenValue: Any? {
+        children.first?.value
     }
 }
 

--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -70,8 +70,8 @@ private struct Differ {
             if String(dumping: received) != String(dumping: expected) {
                 return handleChildless(expected, expectedMirror, received, receivedMirror, level)
             } else if expectedMirror.displayStyle == .enum {
-                let expectedValue = intValue(for: expected)
-                let receivedValue = intValue(for: received)
+                let expectedValue = enumIntValue(for: expected)
+                let receivedValue = enumIntValue(for: received)
                 if expectedValue != receivedValue {
                     return handleChildless(expectedValue, expectedMirror, receivedValue, receivedMirror, level)
                 }
@@ -241,7 +241,7 @@ private struct Differ {
     }
 
     /// Creates int value from Objective-C enum.
-    private func intValue<T>(for object: T) -> Int {
+    private func enumIntValue<T>(for object: T) -> Int {
         withUnsafePointer(to: object) {
             $0.withMemoryRebound(to: Int.self, capacity: 1) {
                 $0.pointee

--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -70,8 +70,8 @@ private struct Differ {
             if String(dumping: received) != String(dumping: expected) {
                 return handleChildless(expected, expectedMirror, received, receivedMirror, level)
             } else if expectedMirror.unwrapped?.displayStyle == .enum {
-                let expectedValue = enumIntValue(for: expected)
-                let receivedValue = enumIntValue(for: received)
+                let expectedValue = intValue(for: expected)
+                let receivedValue = intValue(for: received)
                 if expectedValue != receivedValue {
                     return handleChildless(expectedValue, expectedMirror, receivedValue, receivedMirror, level)
                 }
@@ -169,16 +169,15 @@ private struct Differ {
                     )
                     resultLines.append(Line(contents: childName, indentationLevel: level, canBeOrdered: true, children: children))
                 }
-            } else if Mirror(reflecting: lhs.value).unwrapped?.displayStyle == .enum {
-                let expectedValue = enumIntValue(for: lhs.value)
-                let receivedValue = enumIntValue(for: rhs.value)
-                if expectedValue != receivedValue {
-                    let children = generateExpectedReceiveLines(
-                        String(describing: expectedValue),
-                        String(describing: receivedValue),
-                        level + 1
+            } else {
+                let results = diffLines(lhs.value, rhs.value, level: level + 1)
+                if !results.isEmpty {
+                    let line = Line(contents: childName,
+                        indentationLevel: level,
+                        canBeOrdered: true,
+                        children: results
                     )
-                    resultLines.append(Line(contents: childName, indentationLevel: level, canBeOrdered: true, children: children))
+                    resultLines.append(line)
                 }
             }
         }
@@ -261,7 +260,7 @@ private struct Differ {
     }
 
     /// Creates int value from Objective-C enum.
-    private func enumIntValue<T>(for object: T) -> Int {
+    private func intValue<T>(for object: T) -> Int {
         withUnsafePointer(to: object) {
             $0.withMemoryRebound(to: Int.self, capacity: 1) {
                 $0.pointee

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -385,5 +385,7 @@ extension DifferenceTests {
         ("test_canFindObjCEnumDifference", test_canFindObjCEnumDifference),
         ("test_cannotFindDifferenceWithSameSwiftEnum", test_cannotFindDifferenceWithSameSwiftEnum),
         ("test_cannotFindDifferenceWithSameObjects", test_cannotFindDifferenceWithSameObjects),
+        ("test_canFindObjCEnumDifferenceInArrayOfEnums", test_canFindObjCEnumDifferenceInArrayOfEnums),
+        ("test_canFindObjCEnumDifferenceInArrayOfStructures", test_canFindObjCEnumDifferenceInArrayOfStructures),
     ]
 }

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -20,6 +20,7 @@ fileprivate struct Person: Equatable {
     let petAges: [String: Int]?
     let favoriteFoods: Set<String>?
     let objcEnum: ByteCountFormatter.CountStyle?
+    let elements: [CollectionElement]
 
     init(
         name: String = "Krzysztof",
@@ -28,7 +29,8 @@ fileprivate struct Person: Equatable {
         pet: Pet? = .init(),
         petAges: [String: Int]? = nil,
         favoriteFoods: Set<String>? = nil,
-        objcEnum: ByteCountFormatter.CountStyle = .binary
+        objcEnum: ByteCountFormatter.CountStyle = .binary,
+        elements: [CollectionElement] = []
     ) {
         self.name = name
         self.age = age
@@ -37,6 +39,7 @@ fileprivate struct Person: Equatable {
         self.petAges = petAges
         self.favoriteFoods = favoriteFoods
         self.objcEnum = objcEnum
+        self.elements = elements
     }
 
     struct Address: Equatable {
@@ -68,6 +71,16 @@ fileprivate struct Person: Equatable {
 
         init(name: String = "Fluffy") {
             self.name = name
+        }
+    }
+
+    struct CollectionElement: Equatable {
+        let title: String
+        let objcEnum: ByteCountFormatter.CountStyle
+
+        init(title: String = "title", objcEnum: ByteCountFormatter.CountStyle) {
+            self.title = title
+            self.objcEnum = objcEnum
         }
     }
 }
@@ -296,6 +309,28 @@ class DifferenceTests: XCTestCase {
 
     func test_cannotFindDifferenceWithSameObjects() {
         runTest(expected: truth, received: truth, expectedResults: [""])
+    }
+
+    func test_canFindObjCEnumDifferenceInArrayOfStructures() {
+        let expected = Person(
+            elements: [
+                Person.CollectionElement(objcEnum: .decimal),
+                Person.CollectionElement(objcEnum: .decimal),
+                Person.CollectionElement(objcEnum: .decimal),
+            ]
+        )
+        let received = Person(
+            elements: [
+                Person.CollectionElement(objcEnum: .decimal),
+                Person.CollectionElement(objcEnum: .binary),
+                Person.CollectionElement(objcEnum: .decimal),
+            ]
+        )
+        runTest(
+            expected: expected,
+            received: received,
+            expectedResults: ["style:\n\tReceived: 1\n\tExpected: 0\n"]
+        )
     }
 }
 

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -328,22 +328,22 @@ class DifferenceTests: XCTestCase {
     func test_canFindObjCEnumDifferenceInArrayOfStructures() {
         let expected = Person(
             elements: [
-                Person.CollectionElement(objcEnum: .decimal),
-                Person.CollectionElement(objcEnum: .decimal),
-                Person.CollectionElement(objcEnum: .decimal),
+                Person.CollectionElement(title: "1", objcEnum: .decimal),
+                Person.CollectionElement(title: "2", objcEnum: .decimal),
+                Person.CollectionElement(title: "3", objcEnum: .decimal),
             ]
         )
         let received = Person(
             elements: [
-                Person.CollectionElement(objcEnum: .decimal),
-                Person.CollectionElement(objcEnum: .binary),
-                Person.CollectionElement(objcEnum: .decimal),
+                Person.CollectionElement(title: "1", objcEnum: .decimal),
+                Person.CollectionElement(title: "2", objcEnum: .binary),
+                Person.CollectionElement(title: "3", objcEnum: .decimal),
             ]
         )
         runTest(
             expected: expected,
             received: received,
-            expectedResults: ["TODO"]
+            expectedResults: ["elements:\n\tCollection[1]:\n\t\tobjcEnum:\n\t\t\tReceived: 3\n\t\t\tExpected: 2\n"]
         )
     }
 

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -310,7 +310,7 @@ class DifferenceTests: XCTestCase {
     func test_canFindObjCEnumDifferenceInArrayOfEnums() {
         let expected = [
             ByteCountFormatter.CountStyle.decimal,
-            ByteCountFormatter.CountStyle.binary,
+            ByteCountFormatter.CountStyle.decimal,
             ByteCountFormatter.CountStyle.decimal,
         ]
         let received = [
@@ -321,7 +321,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: expected,
             received: received,
-            expectedResults: ["TODO"]
+            expectedResults: ["Collection[1]:\n|\tReceived: 3\n|\tExpected: 2\n"]
         )
     }
 

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -299,14 +299,6 @@ class DifferenceTests: XCTestCase {
         )
     }
 
-    func test_canFindObjCEnumDifferenceIn() {
-        runTest(
-            expected: ByteCountFormatter.CountStyle.binary,
-            received: ByteCountFormatter.CountStyle.decimal,
-            expectedResults: ["Received: 2\nExpected: 3\n"]
-        )
-    }
-
     func test_canFindObjCEnumDifferenceInArrayOfEnums() {
         let expected = [
             ByteCountFormatter.CountStyle.decimal,

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -343,7 +343,7 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: expected,
             received: received,
-            expectedResults: ["elements:\n\tCollection[1]:\n\t\tobjcEnum:\n\t\t\tReceived: 3\n\t\t\tExpected: 2\n"]
+            expectedResults: ["elements:\n|\tCollection[1]:\n|\t|\tobjcEnum:\n|\t|\t|\tReceived: 3\n|\t|\t|\tExpected: 2\n"]
         )
     }
 

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -299,16 +299,30 @@ class DifferenceTests: XCTestCase {
         )
     }
 
-    func test_cannotFindDifferenceWithSameSwiftEnum() {
+    func test_canFindObjCEnumDifferenceIn() {
         runTest(
-            expected: State.loadedWithNoArguments,
-            received: State.loadedWithNoArguments,
-            expectedResults: [""]
+            expected: ByteCountFormatter.CountStyle.binary,
+            received: ByteCountFormatter.CountStyle.decimal,
+            expectedResults: ["Received: 2\nExpected: 3\n"]
         )
     }
 
-    func test_cannotFindDifferenceWithSameObjects() {
-        runTest(expected: truth, received: truth, expectedResults: [""])
+    func test_canFindObjCEnumDifferenceInArrayOfEnums() {
+        let expected = [
+            ByteCountFormatter.CountStyle.decimal,
+            ByteCountFormatter.CountStyle.binary,
+            ByteCountFormatter.CountStyle.decimal,
+        ]
+        let received = [
+            ByteCountFormatter.CountStyle.decimal,
+            ByteCountFormatter.CountStyle.binary,
+            ByteCountFormatter.CountStyle.decimal,
+        ]
+        runTest(
+            expected: expected,
+            received: received,
+            expectedResults: ["TODO"]
+        )
     }
 
     func test_canFindObjCEnumDifferenceInArrayOfStructures() {
@@ -329,8 +343,21 @@ class DifferenceTests: XCTestCase {
         runTest(
             expected: expected,
             received: received,
-            expectedResults: ["style:\n\tReceived: 1\n\tExpected: 0\n"]
+            expectedResults: ["TODO"]
         )
+    }
+
+
+    func test_cannotFindDifferenceWithSameSwiftEnum() {
+        runTest(
+            expected: State.loadedWithNoArguments,
+            received: State.loadedWithNoArguments,
+            expectedResults: [""]
+        )
+    }
+
+    func test_cannotFindDifferenceWithSameObjects() {
+        runTest(expected: truth, received: truth, expectedResults: [""])
     }
 }
 


### PR DESCRIPTION
- Handle ObjC enum cases when inside collections or deeply inside objects
- Handle children separately to handle inside cases consistently and simplify code
- Add tests for not working cases