### PR TITLE
Update readme to fix deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add `github "krzysztofzablocki/Difference"` to your Cartfile.
 
 ### SwiftPM
 
-Add `.package(name: "Difference", url: "https://github.com/krzysztofzablocki/Difference.git", .branch("master")),` dependency in your Package manifest.
+Add `.package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master")` dependency in your Package manifest.
 
 ## Using lldb
 


### PR DESCRIPTION
Just updated SwiftPM installation in readme to get rid of warning:

`package(name:url:_:)' is deprecated: use specific requirement APIs instead (e.g. use 'branch:' instead of '.branch')`