### PR TITLE
Fix decimal comparison

### DIFF
--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -66,17 +66,8 @@ private struct Differ {
         let expectedMirror = Mirror(reflecting: expected)
         let receivedMirror = Mirror(reflecting: received)
 
-        if expectedMirror.subjectType == Decimal.self || receivedMirror.subjectType == Decimal.self
-        {
-            if let expectedDecimal = expected as? Decimal, let receivedDecimal = received as? Decimal
-            {
-                if expectedDecimal != receivedDecimal {
-                    return generateExpectedReceiveLines("\(expectedDecimal)", "\(receivedDecimal)", level)
-                } else {
-                    return []
-                }
-            }
-            return handleChildless(expected, expectedMirror, received, receivedMirror, level)
+        if let expectedDecimal = expected as? Decimal, let receivedDecimal = received as? Decimal {
+            return expectedDecimal == receivedDecimal ? [] : generateExpectedReceiveLines("\(expectedDecimal)", "\(receivedDecimal)", level)
         }
 
         guard expectedMirror.children.count != 0, receivedMirror.children.count != 0 else {

--- a/Sources/Difference.swift
+++ b/Sources/Difference.swift
@@ -66,6 +66,19 @@ private struct Differ {
         let expectedMirror = Mirror(reflecting: expected)
         let receivedMirror = Mirror(reflecting: received)
 
+        if expectedMirror.subjectType == Decimal.self || receivedMirror.subjectType == Decimal.self
+        {
+            if let expectedDecimal = expected as? Decimal, let receivedDecimal = received as? Decimal
+            {
+                if expectedDecimal != receivedDecimal {
+                    return generateExpectedReceiveLines("\(expectedDecimal)", "\(receivedDecimal)", level)
+                } else {
+                    return []
+                }
+            }
+            return handleChildless(expected, expectedMirror, received, receivedMirror, level)
+        }
+
         guard expectedMirror.children.count != 0, receivedMirror.children.count != 0 else {
             let receivedDump = String(dumping: received)
             if receivedDump != String(dumping: expected) {

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -137,7 +137,15 @@ class DifferenceTests: XCTestCase {
             expectedResults: ["Received: 3\nExpected: 2\n"]
         )
     }
-
+    
+    func testCanFindRootDecimalDifference() {
+        runTest(
+          expected: 30 as Decimal,
+          received: 300 as Decimal,
+          expectedResults: ["Received: 300\nExpected: 30\n"]
+        )
+      }
+    
     fileprivate let truth = Person()
 
     func testCanFindPrimitiveDifference() {

--- a/Tests/DifferenceTests/DifferenceTests.swift
+++ b/Tests/DifferenceTests/DifferenceTests.swift
@@ -140,9 +140,9 @@ class DifferenceTests: XCTestCase {
     
     func testCanFindRootDecimalDifference() {
         runTest(
-          expected: 30 as Decimal,
-          received: 300 as Decimal,
-          expectedResults: ["Received: 300\nExpected: 30\n"]
+            expected: 30 as Decimal,
+            received: 300 as Decimal,
+            expectedResults: ["Received: 300\nExpected: 30\n"]
         )
       }
     


### PR DESCRIPTION
**Issue:**
The current diffing mechanism for `Decimal` types results in output that is either missing, incorrect, or displays internal implementation details (mantissa values), making it difficult to understand actual differences.

**Current Behavior (Examples):**
1.  **Missing Output:** `differ(30 as Decimal, 300 as Decimal)` produces no diff output, despite the values being different.
2.  **Misleading Internal State:** `differ(1.5 as Decimal, 2.5 as Decimal)` outputs a diff of the internal mantissa:
    ```
    _mantissa:
        .0:
            Received: 25
            Expected: 15
    ```
    This reflects the internal representation, not the user-facing numeric values "1.5" and "2.5".

**Root Cause:**
Swift's `Decimal` type has a complex internal structure. The generic diffing logic is relying on default `Equatable` conformance or raw struct field comparison, was inspecting these internal components instead of the interpreted numeric value. This led to comparisons of mantissas and other internal fields, rather than the semantic value of the decimal.

**Changes Implemented:**
This change introduces custom diffing logic for Decimal types to:
*   **Numeric Comparison:** `Decimal` values are now compared based on their actual numeric equality, ensuring that `30` and `300` are correctly identified as different.
*   **Human-Readable Output:** When `Decimal` values are part of a diff, they are now formatted as their standard string/numeric representation (e.g., "1.5", "300") instead of internal components.